### PR TITLE
Eye Gaze and Button FocusTimeout

### DIFF
--- a/Samples/Evergine.MRTK.Demo/Content/Scenes/DemoScene.wescene
+++ b/Samples/Evergine.MRTK.Demo/Content/Scenes/DemoScene.wescene
@@ -314,6 +314,10 @@ Items:
                       X: 1.5
                       Y: 1.5
                       Z: 1.5
+                  - !Evergine.Framework.Assets.AssetSources.Entities.PrefabModification%601[[System.TimeSpan,System.Private.CoreLib]],Evergine.Framework
+                    Name: FocusSelectionTime
+                    Target: a45ee70c-9568-4381-b9bc-8b4133933221
+                    TypedValue: 0:00:00:02.0000000
                 removedComponentList: []
               - !Evergine.Framework.Assets.AssetSources.Entities.PrefabInstanceModel,Evergine.Framework
                 Id: da56fbc2-f77b-47fe-a3b0-88b7c4455127
@@ -337,6 +341,10 @@ Items:
                       X: 1.5
                       Y: 1.5
                       Z: 1.5
+                  - !Evergine.Framework.Assets.AssetSources.Entities.PrefabModification%601[[System.TimeSpan,System.Private.CoreLib]],Evergine.Framework
+                    Name: FocusSelectionTime
+                    Target: a45ee70c-9568-4381-b9bc-8b4133933221
+                    TypedValue: 0:00:00:02.0000000
                 removedComponentList: []
               - !Evergine.Framework.Assets.AssetSources.Entities.PrefabInstanceModel,Evergine.Framework
                 Id: cd9198ed-28f4-4163-95a0-09be18b5e230
@@ -367,6 +375,10 @@ Items:
                       X: 1.5
                       Y: 1.5
                       Z: 1.5
+                  - !Evergine.Framework.Assets.AssetSources.Entities.PrefabModification%601[[System.TimeSpan,System.Private.CoreLib]],Evergine.Framework
+                    Name: FocusSelectionTime
+                    Target: a45ee70c-9568-4381-b9bc-8b4133933221
+                    TypedValue: 0:00:00:02.0000000
                 removedComponentList: []
             Id: 92a40ec7-7556-4edf-9e3e-3ca7b6411c94
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -489,6 +501,7 @@ Items:
                     Id: 001d1547-5ca7-45c9-95d0-ff91e9bf4f4d
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -631,6 +644,7 @@ Items:
                     Id: f671c12c-f6b4-4eb4-b8a1-f0c90452e44d
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -773,6 +787,7 @@ Items:
                     Id: 1e67fac4-9362-46c4-b126-11ca927f891f
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -915,6 +930,7 @@ Items:
                     Id: 6307104e-6339-48ff-aa1e-1ffe8e76f2d1
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1057,6 +1073,7 @@ Items:
                     Id: 2bc3f7dc-8f65-4aa5-b0a2-89f58492237f
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1199,6 +1216,7 @@ Items:
                     Id: 897af695-85ff-48ac-890c-8d83b839e9c6
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1341,6 +1359,7 @@ Items:
                     Id: 1c43d670-49a9-47d2-9540-d91992d0091f
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1483,6 +1502,7 @@ Items:
                     Id: c99f1c5c-1d6f-4ae6-adcb-708b755ccbe5
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1625,6 +1645,7 @@ Items:
                     Id: cd6455b9-9e12-4e0a-b00b-4d80862343d8
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1767,6 +1788,7 @@ Items:
                     Id: 0e5fd8b5-9834-4f98-b3d1-268f3fe2ac2e
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1909,6 +1931,7 @@ Items:
                     Id: cc020fb0-c4ec-489f-84f8-400b82090d88
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2051,6 +2074,7 @@ Items:
                     Id: 156e30b8-01b2-4c88-ab56-3e347e2e0879
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -8234,7 +8258,7 @@ Items:
 Managers:
   - !Evergine.Framework.Managers.EnvironmentManager,Evergine.Framework
     Id: 0b6695c7-b505-442d-b0e2-8e2791c63949
-    IBLReflectionProbe: 82e82c4b-7ed3-42fe-8bd0-848e7a5d2819
+    IBLReflectionProbe: 38a5d19c-8a9d-4210-b582-570fec9b4234
     IntensityMultiplier: 1.0
     IsEnabled: true
     Strategy: Automatically

--- a/Samples/Evergine.MRTK.Demo/Content/Scenes/DemoScene/InstancedEntities
+++ b/Samples/Evergine.MRTK.Demo/Content/Scenes/DemoScene/InstancedEntities
@@ -292,7 +292,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 0f5f8c76-2e80-43d0-8eb9-10ee19263e7e
+                    Id: 99568336-0939-4857-94a6-82ba661c862f
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -322,7 +322,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: c3d82c6f-9d36-4bc2-bada-9f606913ae95
+                        Id: 85bf9ce7-94d2-496c-a2a2-90b10807d968
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -338,7 +338,7 @@ Items:
                           Y: 1.5
                           Z: 1.5
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: fd852121-f85a-41d7-85ed-1ef69b4d525e
+                        Id: 6e00f6d6-398d-4d27-bc07-0bf26e378981
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -355,7 +355,7 @@ Items:
                           Y: 0.0350000001
                           Z: 0.0199999996
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 78555304-92e1-4438-a979-2fa18b4559e1
+                        Id: abef64d5-d42c-40b3-a0a3-78fd02a283a1
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -367,9 +367,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 98932535-b10e-49d6-8eb3-c0c0fe89af4d
+                        Id: f1b37733-85f5-405c-b002-d40b7377de01
                         EndPosition: 0.200000003
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:02.0000000
                         IsEnabled: true
                         PressPosition: 0.300000012
                         ReleasePosition: 0.400000006
@@ -379,10 +380,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 5361a77e-9e06-4e95-92b2-f31187a50986
+                        Id: 0cda22a4-49a2-4709-96f1-c2bb352837bf
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: fedf8741-c441-41d0-94d1-8f60ac94cc89
+                        Id: 37dd345b-052a-42b6-b645-258391b07ec8
                         IsEnabled: true
                         PressedSound: a84df6b7-3a53-46f0-860b-8afa5f39df29
                         ReleasedSound: e4201bf8-b60e-483c-8f72-44c78e353fb3
@@ -394,7 +395,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 71358407-24eb-49d9-b969-e51bdca9bbb0
+                            Id: 36734cf7-df16-46d7-b9f4-072a8c169b85
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -417,7 +418,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 91b555cb-90b5-4604-9719-8f32ce3ad1f2
+                                Id: 89a653b7-dabc-4472-a4bb-3d19d2df86e2
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 0.707106829
@@ -433,26 +434,26 @@ Items:
                                   Y: 0.0399999991
                                   Z: 0.0399999991
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 937a6104-b3ac-445b-a0f4-5cf4c36775c2
+                                Id: 82651f36-31d1-4957-af3f-5cb435fb5496
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 90ff04a5-fc9e-433e-be4b-ff4e024105e5
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                Id: 9694303c-279a-4d65-b821-a6da312f46d6
+                                Id: f82e7108-1924-44d4-8678-5d9d9eb4da94
                                 Diameter: 1.0
                                 Height: 0.299999833
                                 IsEnabled: true
                                 Tessellation: 32
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 36584dd5-f872-4f7f-bbbd-d7f5ee0b0bf1
+                                Id: ae838265-1d4d-4c7d-a937-d31e7ec58e38
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 9bc17298-0ad6-4356-8091-d830702b0f64
+                            Id: d80a2a92-1400-4f41-908b-1061534d5fa1
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: FrontContainer
                             Tag: null
@@ -460,7 +461,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 9213be5c-9928-4fb0-ad1c-4407875ba304
+                                Id: 34a022c4-9486-4765-a26f-67ac16a3531b
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -483,7 +484,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 67ed9ff4-ff22-4f37-8fcd-deffdbdc066a
+                                    Id: f1d0311b-a3e9-46d8-9d3c-562ce0266545
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 0.707106829
@@ -499,26 +500,26 @@ Items:
                                       Y: 0.0399999991
                                       Z: 0.0399999991
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 2659313e-3007-4dfa-85f2-dca02f48765f
+                                    Id: 647b817d-e82c-45bb-8e09-6174b0fe5aac
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 3f1baba7-748b-4798-82af-8cd1de38ff75
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                    Id: d5a7898a-b134-4b2b-a031-0b5565203b71
+                                    Id: 454e8aa9-dcba-48f2-97b6-573553f4611f
                                     Diameter: 0.799999952
                                     Height: 0.299999833
                                     IsEnabled: true
                                     Tessellation: 32
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: c1163bdf-695c-45d6-8871-c58aec9b455e
+                                    Id: e035b1dd-ef59-480b-85cb-c321819d486f
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                   - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                                    Id: 7cf4d5c7-4439-4a88-a182-f772aab02f29
+                                    Id: 24785d34-b33a-4137-80d6-258fb6495931
                                     ChangeColor: true
                                     Compressable: false
                                     FocusedAccentDistance: 0.0
@@ -527,9 +528,9 @@ Items:
                                     MovementScale: 1.0
                                     PressedMaterial: 5690f16f-c7c7-49ac-958c-710cb6375515
                                 Children: []
-                                Id: c7dbe304-a3ca-49ba-87c6-5fcd71a8c3ed
-                            Id: b86cf1b2-0024-4dfc-8c8c-eabcb07bc18b
-                        Id: aa38c484-66bf-4c2c-bc51-534d52cd8f66
+                                Id: 9e6577f0-0908-4705-9b9f-69c3f6927297
+                            Id: 8be2fa76-5398-443a-92dd-aec23156edc4
+                        Id: 78c1be5a-3f4f-4092-966b-2796110afc53
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: SeeItSayItLabel
                         Tag: SeeItSayItLabel
@@ -537,7 +538,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 36a7e073-304b-4a31-968b-69810be11bd2
+                            Id: 740d23bd-2adf-4349-a5d3-610841abea7a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -560,7 +561,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: f94b8ed6-63c1-4506-a0ee-ccede2c62dd2
+                                Id: 0c84d2df-c6eb-4bfb-8fee-c39d7da2d354
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -583,7 +584,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 7e689583-c821-477f-914a-a304919bd586
+                                    Id: e96a5eb4-0ce4-40e6-869b-db30b70f782f
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -599,13 +600,13 @@ Items:
                                       Y: 0.00999999978
                                       Z: 0.00999999978
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 1512b316-0cbf-423c-854b-418b7881c002
+                                    Id: 8729babb-9219-41ca-85b3-a481ed23a226
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 76097084-f629-4699-928e-64711d610d04
+                                    Id: 471f95c1-b85f-47da-a5d3-15869128b0c6
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -621,15 +622,15 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 37862ef4-9cc5-480a-98bc-2b4e269d8849
+                                    Id: d6aaabb1-70ea-48ac-98d2-aca3111e8e1d
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: c5d231d2-353d-414d-a07d-7f6bd87c5cf2
-                            Id: d77ae3c9-e2da-4acf-ac1e-2c0978ee0cc7
+                                Id: 0fa06ca5-5a42-496c-bb52-2e8d7984dae2
+                            Id: 111380bd-5037-4ee9-9ced-0865cdc7c281
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: null
@@ -637,7 +638,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 00485ddc-9818-4db7-baed-0f6da894197a
+                                Id: 98ef8e6a-4924-4091-9ca5-1cbc921fd8bc
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -653,7 +654,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 45c2532d-f3a7-4cf0-af56-6fe1c74eb69d
+                                Id: 06d0f722-8da3-42c7-80d7-2acd23c71c93
                                 Color:
                                   A: 255
                                   B: 255
@@ -677,7 +678,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 96c3c489-4606-45a9-aba5-daf997ef67db
+                                Id: 488dbebd-762f-47f1-8094-9164fc900ad3
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -685,9 +686,9 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: bb2c553a-3053-4957-a2f8-7cc9d975eead
-                        Id: f3a2b765-0771-4e09-b6d7-d73b0a6eddab
-                    Id: 727b65fa-fd13-4655-a704-67621aad0720
+                            Id: 372204c4-9c06-48bd-b265-5118ecb1761a
+                        Id: b63ba216-47fe-44de-b1fc-b4405ef66af8
+                    Id: 7deefd1f-7fcf-4b90-910a-64062cb968ac
                 Id: 749a4a34-04e7-4449-bd9d-7dba47de187e
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableRoundButton
@@ -696,7 +697,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 36463953-3bca-4a07-bd2b-b743da6a0e88
+                    Id: 4046e08d-084f-4121-8629-3b0e02936687
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -726,7 +727,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 81c6fb0e-2b06-4e36-bc1b-369666557866
+                        Id: 5a9ad755-0465-4d2e-8f55-20eb23f7f751
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -742,7 +743,7 @@ Items:
                           Y: 1.5
                           Z: 1.5
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: aae159d5-d697-4c0c-bbc0-d0e8ea611f22
+                        Id: 9936de86-d444-4db0-a8e8-b413084a9dd3
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -759,7 +760,7 @@ Items:
                           Y: 0.0350000001
                           Z: 0.0199999996
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 79ae59ec-8b5e-495d-ae92-e1eaf534ead6
+                        Id: 4e7db208-19ca-4fe5-95ee-2ae54453a37a
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -771,9 +772,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: c6078f29-65f5-4553-84e7-c4641331c05c
+                        Id: 2f3fe203-39b8-41b4-9cf7-7948c6b7a6d0
                         EndPosition: 0.200000003
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:02.0000000
                         IsEnabled: true
                         PressPosition: 0.300000012
                         ReleasePosition: 0.400000006
@@ -783,10 +785,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: ea7671c0-0a79-4b3a-a92c-7c2bef919c87
+                        Id: 0825f135-561b-4526-92b7-43831ea2ced8
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 07469d7b-4ca0-4819-8637-d629c80b0512
+                        Id: 02e804f0-1302-4948-bb73-e74feb05e8b4
                         IsEnabled: true
                         PressedSound: a84df6b7-3a53-46f0-860b-8afa5f39df29
                         ReleasedSound: e4201bf8-b60e-483c-8f72-44c78e353fb3
@@ -798,7 +800,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: cac7cafd-4cc5-4f4c-975d-28f24d1c78d3
+                            Id: db20a6a1-ed35-4401-b6a3-c11b1941dbe8
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -821,7 +823,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 4af646ad-c584-40c9-82ec-87124ef7c3c1
+                                Id: dc579e3e-7337-44d7-83c5-a0f13be826d7
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 0.707106829
@@ -837,26 +839,26 @@ Items:
                                   Y: 0.0399999991
                                   Z: 0.0399999991
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 788c3e02-51c8-4c61-97d8-049ddae9689d
+                                Id: ae367f64-cb19-40da-b86a-d7282261b761
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 90ff04a5-fc9e-433e-be4b-ff4e024105e5
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                Id: 3a3bf116-630c-45d0-8b6e-1aafe884a5b7
+                                Id: 6d74c76c-fa83-4f51-81b0-e740b84961f3
                                 Diameter: 1.0
                                 Height: 0.299999833
                                 IsEnabled: true
                                 Tessellation: 32
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: e4b01165-a1ba-46b5-8d1a-b4053becb8f0
+                                Id: 455066ea-0758-43ea-aaca-a76fc2c6ca1e
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 060999c3-f956-40ca-a23e-6b01e130d0e1
+                            Id: 874a723c-ebdd-4cb2-a385-d03e38cc594f
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: FrontContainer
                             Tag: null
@@ -864,7 +866,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: f2d53eb2-1c94-4a68-802b-15365b0e9f47
+                                Id: 0332b4d8-7145-4617-a97d-d0451deab843
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -887,7 +889,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 982ffb15-8171-42e8-8917-4631cf13d9fe
+                                    Id: 2a2f2293-69ef-4abe-b4b9-5e4078164076
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 0.707106829
@@ -903,26 +905,26 @@ Items:
                                       Y: 0.0399999991
                                       Z: 0.0399999991
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 88a8d984-e526-439e-9b84-c733eeeb087d
+                                    Id: 491ac602-6f93-45a5-b9ee-ad7f85b9c73c
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 3f1baba7-748b-4798-82af-8cd1de38ff75
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                    Id: a4e46cbd-ed6a-43c1-b35a-f9bcb6971b26
+                                    Id: ec2883ba-ba92-4eb9-b911-533ee5f93115
                                     Diameter: 0.799999952
                                     Height: 0.299999833
                                     IsEnabled: true
                                     Tessellation: 32
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 510520d0-5a54-4392-a9ff-cde58a0f8e94
+                                    Id: dd74a41e-3a77-4c07-912d-000f2d321a02
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                   - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                                    Id: 03e6bc9d-4f1c-457a-a9de-b726a54c1ac3
+                                    Id: 7a2b8c03-2c70-4fc2-9471-2f1e6e570d23
                                     ChangeColor: true
                                     Compressable: false
                                     FocusedAccentDistance: 0.0
@@ -931,9 +933,9 @@ Items:
                                     MovementScale: 1.0
                                     PressedMaterial: 5690f16f-c7c7-49ac-958c-710cb6375515
                                 Children: []
-                                Id: 8a988495-e1ce-485a-802d-1ca742d6ebbe
-                            Id: 7991241a-fe69-4094-9269-38cd683ccaa1
-                        Id: 87da8074-63f6-4320-a23b-b59b8185ca98
+                                Id: 66870d98-d705-43eb-879d-9cf076a7e613
+                            Id: fdcab321-d397-4466-b479-381dba347130
+                        Id: 466460eb-6e2b-4fbf-a4a7-1a67670c3755
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: SeeItSayItLabel
                         Tag: SeeItSayItLabel
@@ -941,7 +943,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 456c4f2c-2ae8-43b0-9a3f-078c704d00f4
+                            Id: 8b867ea6-d09d-4c55-9d12-b000b7188ade
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -964,7 +966,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 6424d940-6d4c-48fc-a404-0246473be0a1
+                                Id: 41e6c98b-10b2-4102-bfa9-7264497e28dd
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -987,7 +989,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 612eeb50-dc66-4f7a-8e13-c719e7cb0a58
+                                    Id: d0c91be7-f8d9-4b0e-a462-7b9ccd8beb43
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -1003,13 +1005,13 @@ Items:
                                       Y: 0.00999999978
                                       Z: 0.00999999978
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 5295005d-5938-4b06-8092-f5ca4eee5fb9
+                                    Id: ab9ce003-d296-43d2-8e3f-cdb0fb06b4dc
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: e2ededb3-aa20-4521-a87b-3fac3f8e9324
+                                    Id: a09ededb-b804-4fec-8730-1b920b931fea
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -1025,15 +1027,15 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 9c268ed0-5dc5-441b-abaf-2c8b6cd0c87d
+                                    Id: b5f624a9-8a57-4520-bde9-d3e8b7d82214
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 922b675f-1ca6-4fa5-bfe5-7e697f2a79ac
-                            Id: facbf5ee-ba3b-4afa-984d-fe0825cdb2fd
+                                Id: 690714c5-9fa9-461f-bc4b-352e52bf4000
+                            Id: 377938e0-0024-4740-a44a-b2574a62a13b
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: null
@@ -1041,7 +1043,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: e57f6b33-7e41-4707-ae78-fe65910dc8e1
+                                Id: b7ffce07-dfac-45f1-814e-21e8fc9cb89b
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -1057,7 +1059,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 845b28fd-5906-4931-bbbe-52acfd611bdf
+                                Id: 9d591411-6636-4c1c-8fba-9394aaf569ad
                                 Color:
                                   A: 255
                                   B: 255
@@ -1081,7 +1083,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: fc76cd82-fac3-4958-a97e-2d82ff9315fa
+                                Id: 54713c73-4d1b-49b4-8a79-07d20eaee1c3
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -1089,9 +1091,9 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: e3d83ca4-8609-4251-afba-319af3f2522a
-                        Id: c2d113a6-0787-4124-94e3-93c25fa5f84a
-                    Id: fb29fb30-457e-445f-a5cf-b7e740ad6530
+                            Id: 2a070568-cc81-4550-b0ed-d60b42b53f67
+                        Id: d9015ec9-ee60-436d-9f1a-51d49282871a
+                    Id: 67189bca-0d03-49f1-8c5d-0f24bfaea6c6
                 Id: da56fbc2-f77b-47fe-a3b0-88b7c4455127
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableRoundButton
@@ -1100,7 +1102,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 5bfdc551-c1d8-4681-8230-4c25285267f7
+                    Id: d44063e9-449c-4a71-bb5b-a3677faf628d
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -1130,7 +1132,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 7ca02ca3-3f02-4ffc-80b3-33f0c258e016
+                        Id: 267f9248-56f1-44be-82e6-d303710a4a0e
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -1146,7 +1148,7 @@ Items:
                           Y: 1.5
                           Z: 1.5
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: a196ea6a-9f26-4fcd-a3de-b9dc33d9e9c9
+                        Id: 95d2cc64-39f0-46a6-9070-0085eea38b43
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -1163,7 +1165,7 @@ Items:
                           Y: 0.0350000001
                           Z: 0.0199999996
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 8d67900e-74a1-4044-90ff-846f52f3c493
+                        Id: 58e56a12-5966-4a4a-b3c0-935c72798282
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -1175,9 +1177,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 83cc3eb2-0d0e-4acb-b13a-2bb076e4066f
+                        Id: ce752c61-6c09-4cda-8b6e-91c8b6b15b9e
                         EndPosition: 0.200000003
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:02.0000000
                         IsEnabled: true
                         PressPosition: 0.300000012
                         ReleasePosition: 0.400000006
@@ -1187,10 +1190,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: dccf2591-f55b-45f1-800c-ef273c51a207
+                        Id: d22aab31-6de8-47a6-9af4-ef481d89ab97
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 892d9695-e6b7-4573-82e8-f816ad8b48c8
+                        Id: 0ef4f727-2f16-4960-8007-7319418e5bc1
                         IsEnabled: true
                         PressedSound: a84df6b7-3a53-46f0-860b-8afa5f39df29
                         ReleasedSound: e4201bf8-b60e-483c-8f72-44c78e353fb3
@@ -1202,7 +1205,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 8969eac0-c406-442c-9062-3902a0b36170
+                            Id: ba5ef56e-5424-4348-ae26-da1b425dbd7a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -1225,7 +1228,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 89878d71-6a48-4716-aad8-93ceaadc9ea1
+                                Id: 42ad8ef5-cbb6-4baa-93b5-168dfe52480b
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 0.707106829
@@ -1241,26 +1244,26 @@ Items:
                                   Y: 0.0399999991
                                   Z: 0.0399999991
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 24db9c78-4f62-4302-82c9-8ca6f048f10c
+                                Id: 783ef9d2-4706-42b3-8a9a-814612694890
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 90ff04a5-fc9e-433e-be4b-ff4e024105e5
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                Id: 8b53fae2-319a-40b5-a983-817855c2bee7
+                                Id: aefec256-fdb0-4664-abfd-9e65c47c854c
                                 Diameter: 1.0
                                 Height: 0.299999833
                                 IsEnabled: true
                                 Tessellation: 32
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 2986e58a-ab6c-47ef-94d3-5698892e3cca
+                                Id: 97be73f9-c63d-4b4f-b3a3-c734b097bca3
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: c6a50dde-461a-4766-b3f5-f3904a35d319
+                            Id: 3b48feef-364f-4763-852a-06abcdac2a75
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: FrontContainer
                             Tag: null
@@ -1268,7 +1271,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 6286d6e7-5c76-4014-93d3-75ce0f816432
+                                Id: c0701f1e-6822-4af9-b49f-b6fc98504c0f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -1291,7 +1294,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 1b852554-6eeb-4a17-8a66-8f9868453df6
+                                    Id: 4a095a92-391c-4e16-94ef-506a511488c9
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 0.707106829
@@ -1307,26 +1310,26 @@ Items:
                                       Y: 0.0399999991
                                       Z: 0.0399999991
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 0620f0c0-4797-4c7a-82bb-f73cebba16da
+                                    Id: f48bc293-25c2-4fe5-ac1e-ca6d0939626f
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 3f1baba7-748b-4798-82af-8cd1de38ff75
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                                    Id: e69a5a02-c4ec-42da-8bfc-7f2b6073a811
+                                    Id: de2196b9-2bbb-4e28-b621-ba52068c8897
                                     Diameter: 0.799999952
                                     Height: 0.299999833
                                     IsEnabled: true
                                     Tessellation: 32
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 1e63567e-1555-4687-b118-e8b21f136bb1
+                                    Id: e688158f-1776-464a-9081-b710fed52138
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                   - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                                    Id: eda2116f-c0d1-465d-b19d-3ca2f1c5d557
+                                    Id: dd14d783-cf22-4c1a-80ab-d71ef5fbf71a
                                     ChangeColor: true
                                     Compressable: false
                                     FocusedAccentDistance: 0.0
@@ -1335,9 +1338,9 @@ Items:
                                     MovementScale: 1.0
                                     PressedMaterial: 5690f16f-c7c7-49ac-958c-710cb6375515
                                 Children: []
-                                Id: ad7e86f8-6310-4dd9-8844-bbdbacb5dcf0
-                            Id: de4a5b01-f217-4d17-bb84-ee87a15fd01f
-                        Id: 429c5610-8e12-4f54-8767-fcede2ca8772
+                                Id: 94bd51ac-0420-4367-a529-2c84fc9430ea
+                            Id: b26095e6-bb55-480a-a0e2-aa2f21e2e624
+                        Id: 7fc6d70f-9d47-4b8d-bc9d-3c0ec9607568
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: SeeItSayItLabel
                         Tag: SeeItSayItLabel
@@ -1345,7 +1348,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: acb22ade-7f35-49a6-8e1f-6661a2edaa23
+                            Id: 0f939039-05ac-4744-9b70-a46a430f729e
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -1368,7 +1371,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 527a2bab-c38c-4c86-9b06-e01b85a9825e
+                                Id: 64c38be8-c007-40c0-9122-126e5854fbc1
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -1391,7 +1394,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 40ade468-20f4-4b68-b3eb-5b64620faf81
+                                    Id: 3c4ade3f-02d6-4c73-9657-c8fff5175f47
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -1407,13 +1410,13 @@ Items:
                                       Y: 0.00999999978
                                       Z: 0.00999999978
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: b218bff8-e8a6-42b4-9ece-da312abd9d57
+                                    Id: 439bcfe3-c0b3-4ead-afdf-73e9c93f1f40
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 473a5298-18f5-40f7-ab13-fb8bc072899a
+                                    Id: 78baac92-75d3-4463-a1f2-d3b2bfe48537
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -1429,15 +1432,15 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: ff7b26dc-21bf-466b-bd9c-733ad416f110
+                                    Id: 0f937bd8-aefd-45b9-ae3d-8dde58b40ecb
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 59eca10c-bb10-4580-84cd-ce94a7fa9fd9
-                            Id: bfca25d6-cc42-4af7-9008-c2aa8244e128
+                                Id: 89073f3a-dce3-4751-9ad7-4db0418030c3
+                            Id: 3d778a62-0f0f-4257-9c37-26d5b335609e
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: null
@@ -1445,7 +1448,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 6ed8447b-44ec-43ad-b2fe-e05c85c23e51
+                                Id: 466cf203-eff3-4a65-8b7f-749319a09fcf
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -1461,7 +1464,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 838169ff-0ec4-49b5-862f-5bac8c8376e1
+                                Id: 489d7963-ba0e-496a-88da-b634c3a90353
                                 Color:
                                   A: 255
                                   B: 255
@@ -1485,7 +1488,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 2812acb4-0386-4946-9432-202ea9cc6d56
+                                Id: c4ef8e61-d658-4736-9462-3400890ae8fc
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -1493,9 +1496,9 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: d93c5472-32f6-498e-a5a9-b23054d6d746
-                        Id: acf6e512-c567-484b-9660-3c6640d55329
-                    Id: 3ed3b0a5-b376-4a0b-82c0-75811419d652
+                            Id: e015aecc-9222-4724-9dee-350ceba52e1e
+                        Id: e989b94a-5833-4ddd-a288-1f438abe2d4c
+                    Id: 304dc7b8-3d09-43f8-b822-3bf6f84a57ae
                 Id: cd9198ed-28f4-4163-95a0-09be18b5e230
             Id: 92a40ec7-7556-4edf-9e3e-3ca7b6411c94
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -1618,6 +1621,7 @@ Items:
                     Id: 001d1547-5ca7-45c9-95d0-ff91e9bf4f4d
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1760,6 +1764,7 @@ Items:
                     Id: f671c12c-f6b4-4eb4-b8a1-f0c90452e44d
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -1902,6 +1907,7 @@ Items:
                     Id: 1e67fac4-9362-46c4-b126-11ca927f891f
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2044,6 +2050,7 @@ Items:
                     Id: 6307104e-6339-48ff-aa1e-1ffe8e76f2d1
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2186,6 +2193,7 @@ Items:
                     Id: 2bc3f7dc-8f65-4aa5-b0a2-89f58492237f
                     EndPosition: -0.400000006
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2328,6 +2336,7 @@ Items:
                     Id: 897af695-85ff-48ac-890c-8d83b839e9c6
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2470,6 +2479,7 @@ Items:
                     Id: 1c43d670-49a9-47d2-9540-d91992d0091f
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2612,6 +2622,7 @@ Items:
                     Id: c99f1c5c-1d6f-4ae6-adcb-708b755ccbe5
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2754,6 +2765,7 @@ Items:
                     Id: cd6455b9-9e12-4e0a-b00b-4d80862343d8
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -2896,6 +2908,7 @@ Items:
                     Id: 0e5fd8b5-9834-4f98-b3d1-268f3fe2ac2e
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -3038,6 +3051,7 @@ Items:
                     Id: cc020fb0-c4ec-489f-84f8-400b82090d88
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -3180,6 +3194,7 @@ Items:
                     Id: 156e30b8-01b2-4c88-ab56-3e347e2e0879
                     EndPosition: -0.100000001
                     EnforceFrontPush: false
+                    FocusSelectionTime: 0:00:00:00.0000000
                     IsEnabled: true
                     PressPosition: 0.100000001
                     ReleasePosition: 0.300000012
@@ -3520,7 +3535,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 53ec911b-1a12-4bd9-8fdd-fb415b298c39
+                    Id: 12e565c2-f153-42ae-96a9-c237494913dd
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -3571,7 +3586,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: f8bdb517-d3dc-4212-92d2-fac55c3580de
+                        Id: 5ed7d9a2-9884-4cb9-87e5-50a6ab9c3442
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -3587,7 +3602,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: f5770d15-54b4-415f-a133-8eaeb87b8434
+                        Id: d8d73844-741b-46cf-818d-13a7813d02e9
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -3604,7 +3619,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 125c35fd-f306-47f2-b401-db3d95dbc68e
+                        Id: e7e322b5-b303-4583-a67a-01ba39c46a35
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -3616,9 +3631,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: fb090b2b-479c-4e2b-ab5e-6540254a74b9
+                        Id: 7963a7b2-dde7-4155-b44a-d6af6faf8847
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -3628,10 +3644,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: b78f9883-0740-4b38-9611-32c7906a66c3
+                        Id: 1b8b4dd5-ff45-49d6-b964-2298203cb0df
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 167649b8-1bb9-4b74-9fd7-c39c292a756d
+                        Id: a6cf9998-fa7d-4d13-9d2f-55bedd7e5bf2
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -3643,7 +3659,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 16e9ca20-4ade-4efc-8146-a54d9ba4d5ee
+                            Id: 6977b594-2e27-4403-8fe5-0c1e5fecc155
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -3659,13 +3675,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 5a7cf83b-9e91-415b-9bc1-3b39b36c7bab
+                            Id: 872ba84a-29d1-40dd-b7a6-15487f824eb7
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: d70be9e7-5ceb-4707-b626-f7fadcb34824
+                            Id: 42b09769-f6b5-460b-b935-e773d0d2d146
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -3681,14 +3697,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 2ab917eb-2304-4fa4-be58-db4a87238756
+                            Id: 4c782901-8f4f-4251-afa0-b5fbcc5975e2
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: f5f77292-bbf4-421f-9848-51e682a95eef
+                        Id: d985777c-5683-4b00-8617-f7e6df5c1281
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -3696,7 +3712,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: fd0b2cee-12cc-4972-88b5-607a19657685
+                            Id: a6d943de-a26f-4b03-99e9-2a86254f3519
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -3712,7 +3728,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 68a4be8c-f449-4579-a80e-0e5bfe6ec765
+                            Id: e4b5a468-49b9-4849-93c7-0e17f9f640b5
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -3728,7 +3744,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 4f119706-908a-465a-86d1-b4cc12786da3
+                                Id: 170bf5d5-921a-4eb6-be60-1755e2880b03
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -3744,13 +3760,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: eed2ec27-10e4-416f-b132-9b1f3d04027d
+                                Id: 67463ac1-5789-4e0d-be5c-f7eb26e408cb
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: c4aa82cb-d569-4d57-9a96-a7cbd1e1f90c
+                                Id: 1d5ce233-ddb2-430f-840e-6fa99ce4d440
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -3766,14 +3782,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: ca8e2f36-ef14-44c1-b464-cfe548fc942c
+                                Id: 5f1cc907-8ccf-4d0e-9aca-7c56aa70db4e
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 83535244-1f05-438d-9cef-ab491d060fbf
+                            Id: e788b7dd-8db3-4c49-a6d9-bd41dfdd13eb
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -3781,7 +3797,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 0317b5b9-02fc-4e86-be1c-efc63dac50b3
+                                Id: f6d31bfc-a6db-47ee-9449-c164440a127a
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -3797,7 +3813,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 4075bc53-3dea-4425-aff2-a3830b06d68c
+                                Id: 70232d1e-ec85-4194-9c21-519396bba313
                                 Color:
                                   A: 255
                                   B: 255
@@ -3821,7 +3837,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 730e7706-32d2-42b9-aa0e-6bec8ede29b4
+                                Id: 94cdee38-3e04-40f7-b278-f11e07f96380
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -3829,8 +3845,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 9e4dbc8b-ceab-49c1-9d51-98060694b842
-                        Id: 37c7f9d0-5dcb-4503-b634-3a2f6b3989f4
+                            Id: c7e22724-7742-48a5-a65e-37315a5dac8c
+                        Id: 7df50f5c-ea30-4a5a-8187-c8baf54ed0f7
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -3838,7 +3854,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 70549194-8b5d-45df-8bb5-defe54992629
+                            Id: 5f623633-1233-43c7-8826-4faacd1fab9d
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -3854,7 +3870,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 38c2fcd9-1f2b-4812-8123-841293498993
+                            Id: f94f1143-ef78-479a-8da5-5ba8e2cffeb2
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -3870,7 +3886,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 193fab9f-39fa-46ee-9d10-4c1d46defb45
+                                Id: ff2b5f60-1e6d-4153-bc46-2e3a06b691c8
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -3886,13 +3902,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 32d56f03-0118-4d5b-8bd8-7f617dba9dce
+                                Id: 032d2cb2-ba41-4fd0-a45c-0cec133a5c56
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: a0303583-2833-4a3e-b851-af6d57041a2a
+                                Id: 64caa733-17df-468d-a677-da41334db6dd
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -3902,7 +3918,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: c9075aa0-2eba-4d37-a1c8-63f3f4b13747
+                                Id: 2161944d-b7a6-4f5f-a224-b82610c824fb
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -3916,7 +3932,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: a7f52dd9-172b-4b57-b594-d78c767154b4
+                                    Id: 3a8f2d4f-18cf-458c-8dbb-f4def0f14e9a
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -3932,13 +3948,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 9ad36883-4ab8-4f06-9bde-1b7a65ceea6d
+                                    Id: b4c58152-b2c3-4b89-b62b-9825cf9d4e0b
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 9686b30f-caef-4e7b-b8cd-c578ac87ec38
+                                    Id: 01b440f7-3ff7-40ff-bdee-05f95a01943f
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -3954,17 +3970,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 430153d0-f26b-4bed-be37-5c4d3ba0c752
+                                    Id: 340f159c-0333-4717-9870-1f93b77ffc9a
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 1c6511b8-0dae-43a2-8f92-ab549fcfdcfc
-                            Id: ecf0dacc-ee02-4303-9696-46b892425691
-                        Id: 6038f6dc-5045-4532-b078-682f112769b0
-                    Id: fff23c9a-b9df-4764-bca5-17c0932ed404
+                                Id: 29ae4398-bb26-46b0-9223-4b7e0ad32d17
+                            Id: 0e983721-61ed-4b60-9273-d1eb4cf54041
+                        Id: a4a19e46-73f7-42ad-ba46-179a1df66a93
+                    Id: af3d6e45-4e97-48c6-8aca-a2484321ed01
                 Id: 6e436e58-38b0-4a8e-9002-abcc21627dcb
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated32x32mm
@@ -3973,7 +3989,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 4661a39e-9082-456f-8ee4-dff976b99238
+                    Id: ef674d1a-8218-4029-a787-5ee7e6fd1b12
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -4024,7 +4040,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 01d59086-b379-4021-aa47-8ebef0d0c7c4
+                        Id: a48118c8-8290-45d9-9c35-e5e0709f080a
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -4040,7 +4056,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: c9939ac9-89bb-44fc-a21e-11b21cc049e0
+                        Id: 9329e54e-06f7-4641-bf4f-a5f00adcda72
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -4057,7 +4073,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 19c76058-5e87-4448-97b5-51cc56109bd8
+                        Id: 9841031b-ef3e-4ac3-b6cc-db2d23ebd8f2
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -4069,9 +4085,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: bc6e2cb5-1161-4897-8aa2-eaf966f3f85e
+                        Id: e0afce25-d35b-4363-a97a-4578ba81a981
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -4081,10 +4098,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 1f424b8d-711d-4137-b37c-ec5858f29e38
+                        Id: aacfed1e-818a-4f86-893b-6b706f40e0a2
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 139c0ada-0a74-4303-b0e0-e877404ebe5c
+                        Id: b27a691d-b529-4bff-864c-40ad9254c5be
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -4096,7 +4113,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 9325c62b-347d-489f-91d2-c8d8868a9e82
+                            Id: caa7f43c-ed11-4e25-9d45-866100cb9038
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4112,13 +4129,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 35d665a1-9eaf-4848-ae67-cef32403b10a
+                            Id: aa1f6159-5029-44c9-9762-6ee5d0b0fb05
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 9ecee1d0-9889-4f1f-bf22-a10393a0cfd1
+                            Id: d8479700-d2eb-4287-b853-ee8c3cbd5fc5
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -4134,14 +4151,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 3767e448-621d-4cbb-afc4-22c0dae6e731
+                            Id: 8a5ffa7c-eb7b-4f45-9e95-603e55c48a80
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: cbce2617-f00d-424e-99b3-ef0f32872ace
+                        Id: cb0af07f-6fe8-4a65-9899-4ed00fafbee9
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -4149,7 +4166,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 7d6bec7f-a34b-4fc5-8681-6251a1cbff01
+                            Id: 3e7ecdc4-4769-44eb-96f2-117dd36f527a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4165,7 +4182,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: e8c01528-47b2-48f0-9590-7b435c6fb3b2
+                            Id: 99a33a81-0df1-4782-90e5-370790d66d10
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -4181,7 +4198,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 23031fc4-1db3-4094-bff5-51b778c6ac95
+                                Id: 025d1e34-4a13-407c-a249-f2fa4c70df18
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4197,13 +4214,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: f67ad678-85bf-49d6-a687-a02f39e2b0f2
+                                Id: c75dc567-23cc-4369-9b96-37000d6e1185
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 46124572-3a1a-4f31-aecc-294c3b3c0a02
+                                Id: 5acffd67-e28c-4fa8-b839-22a72f52b486
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -4219,14 +4236,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: d1b8675c-d189-4ed7-9e12-147ede390d2f
+                                Id: 8de99610-9f43-469b-ad23-69a8d22b8461
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 361cb56d-1c7f-457a-9451-c81aae6ee8b2
+                            Id: 328553d7-9f0a-4c0b-8d75-661b67dc8ea5
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -4234,7 +4251,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: bcd4f16e-3b2f-4b33-8190-6649d4dae2a8
+                                Id: 7267722d-8fb5-4597-97e6-b8a3fd5bae82
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4250,7 +4267,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 3afc3601-2079-4c74-99a4-f6c7b6f62e2d
+                                Id: 5b2bd66a-3cc0-40ad-af8d-b3e3c918f032
                                 Color:
                                   A: 255
                                   B: 255
@@ -4274,7 +4291,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: f9a3b71b-11ff-4894-a58a-3eb8873bcc03
+                                Id: 80169d66-774b-4850-a6b6-8e2369738247
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -4282,8 +4299,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 1775e0d0-3ba8-41c9-8a37-9922a343e5bd
-                        Id: e4725e6d-4ad0-43bb-a359-e770f0b628d1
+                            Id: 4f815929-5ea7-4b75-bc88-933b97d553b9
+                        Id: ad9e8999-6729-4bc8-a1e0-e52acf429039
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -4291,7 +4308,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: c5df2097-8a1a-4976-8fbc-8abd0857744b
+                            Id: 44f57006-7488-4db5-b093-1a6a67c0b1f8
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4307,7 +4324,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: c703cfec-33e4-4d14-938e-fa983bf1eaee
+                            Id: 61985ffe-c225-4c12-8e8d-bb200ad1ab03
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -4323,7 +4340,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 2f3e140e-04a0-4591-8153-16639f7b229b
+                                Id: a41e7529-2676-4f9c-880a-cf4370c46e65
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4339,13 +4356,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 9248c72d-19bc-4e3d-a900-6f196bc40280
+                                Id: a302cc4f-27fc-491e-83c9-e0fffcc675df
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: fe42be16-734b-45a5-82d9-918d1fb0246e
+                                Id: bcb317bd-ce88-4985-9159-38f595c1219b
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -4355,7 +4372,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 629efb49-44b7-466e-9ed8-abe58ae2cb1a
+                                Id: 475db7a1-2a12-4fdc-a5ba-7d5cfa460f52
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -4369,7 +4386,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: c452e293-e9a8-43ee-a59f-056888e6da1e
+                                    Id: 7e8ef604-b4ac-433f-ae71-a53df16ddfac
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -4385,13 +4402,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 83e68b4a-253b-4cce-9033-711835626a37
+                                    Id: 589e5cc1-eb0c-4a50-b178-8b2854dd6cbd
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 0ba92052-2ec6-4dfb-8c65-d4d13dca6f2a
+                                    Id: 15695bb8-d599-4b32-b1e5-a3560e6c5b18
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -4407,17 +4424,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 5000abbc-f5f1-46c4-bdfc-531c2365ad1e
+                                    Id: 7af94529-2b62-4471-ac71-8b38421fe4bc
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: b4e08c64-5e8d-4e71-ac5a-e031323eeb5a
-                            Id: 2ab5f839-3418-4666-b8ba-174530b7aa32
-                        Id: 90cb03a4-856d-4764-ac0f-9a581023cd98
-                    Id: 9382f798-a143-4a4a-9fd0-ad08dac72c01
+                                Id: d4662a51-01bd-4a7e-aa57-a9c9a6c24a4e
+                            Id: a3df7882-ea1b-43c3-8c2f-4c422c9ab867
+                        Id: cb5cb727-1eff-4bd7-9baf-7dbd619d748e
+                    Id: c2aa9da9-f5d4-4a19-a495-a1e8b3a27e94
                 Id: e2a78393-474d-4ef6-b063-9ff449a97ec6
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated40x40mm
@@ -4426,7 +4443,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 99210121-8477-4e88-a760-23b33dcd0b3a
+                    Id: bf3055b7-e155-4aad-a65a-88376cdace39
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -4477,7 +4494,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 9c6c69e3-d896-484d-be48-6ddc170e02f7
+                        Id: d207f508-cf5a-408c-9c04-834701d02fff
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -4493,7 +4510,7 @@ Items:
                           Y: 1.25
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: db64ecf8-ab43-4065-9f7a-3f007db428c8
+                        Id: 4a4dedb0-0e49-4487-9826-385b4c8099a6
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -4510,7 +4527,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 7a018ec6-003c-4057-a64e-085d01565a18
+                        Id: d26257ef-09d3-4ad2-9211-ac9878d71363
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -4522,9 +4539,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 52d471bf-c0da-4884-b4d5-61e72cb46d8c
+                        Id: 4114901b-bace-405e-86f4-a2a02f8d4724
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -4534,10 +4552,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 43d54410-2eca-4a84-9353-f9bb1fa04ec4
+                        Id: 1b192e5c-9eae-4450-b2e9-fd33e5194eec
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 2c9db996-eb11-4f15-8305-5f73affa6eef
+                        Id: ae3e11f3-6c9c-4371-b47b-6a9984cbd6af
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -4549,7 +4567,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: a8fcb450-7097-46ae-af60-94e58a25d7ee
+                            Id: 8baff456-1daa-4ce5-aee1-9a107d934797
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4565,13 +4583,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: db1240b0-c38c-4f6c-a03e-a788d3bae543
+                            Id: 302c92ab-480d-4391-bda8-a656d829bd41
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: d3c3f015-80f8-4bdf-ab76-dc52265f9326
+                            Id: e417c881-00dd-4c2a-acee-8845b5d41071
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -4587,14 +4605,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: b77f2b50-a770-49c4-ad03-2223287389ea
+                            Id: 678835e7-0fcf-41d0-8398-7199fb548d2a
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: c71500c0-2e0d-4d45-b5eb-4cd20fd5127c
+                        Id: 7a412b1b-c739-48f6-9b45-1c47d3c640fc
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -4602,7 +4620,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 3c62b05b-6bf4-46dc-a12a-33b28444f873
+                            Id: 3c7a9a68-4e1f-41ed-9f7b-354a3139337b
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4618,7 +4636,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 654c3dd7-4b90-46be-9d57-c5520e7bafe7
+                            Id: 3944f4f2-996e-407e-98ba-6c4e794c2b56
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -4634,7 +4652,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: dd8d9458-f9c5-4362-aea1-a7f715eb078d
+                                Id: 80490c38-967e-4d50-aa61-83dde1168c46
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4650,13 +4668,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 0fc844d1-a698-489c-a2e0-1359f7a5c30a
+                                Id: 87b18f0f-f817-4f98-926f-dd1185779dc6
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 8a8e2af4-a9fc-4f44-bba1-79acf3b172e1
+                                Id: 5c4ed932-9f61-4baa-bdab-bfed0d89115c
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -4672,14 +4690,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 1e8b4695-c0c2-474c-b94f-1ea93c5c65b4
+                                Id: 8098b143-37b0-4673-b3b1-9389d9772233
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 85872348-2efc-457d-9ecb-4c375475e697
+                            Id: 6cbaa3c0-6f0f-42a9-b3aa-14276b88647c
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -4687,7 +4705,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: a59c0d92-fce1-4a60-bf55-5b87b2327db9
+                                Id: 0de00d85-431a-4dcb-b7e8-98db57321df4
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4703,7 +4721,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: fef34266-20f1-4e7c-b252-a6c4600c4c4f
+                                Id: 196d914f-0f7c-468e-a2cc-392da756f4d1
                                 Color:
                                   A: 255
                                   B: 255
@@ -4727,7 +4745,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: a5146386-ccf3-4db3-82af-3843019e7a8e
+                                Id: a86b07df-9a21-41ed-a4c2-c3136f8009ee
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -4735,8 +4753,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 1402a508-485a-4e63-8c8d-85ecbda39123
-                        Id: 21fef45e-370b-41b2-ab64-f501e0ed2f72
+                            Id: cdd321c6-46cf-46f9-9799-eae5663d6b9f
+                        Id: 535bfb57-5451-41a7-af8e-d39b19cfd0fa
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -4744,7 +4762,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: eed207b9-1a5b-466e-ad5f-742288fa7a15
+                            Id: d7a083d8-1ecb-4263-a214-dcb38a81a6b9
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -4760,7 +4778,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: ff5536e9-67d4-44b0-9524-30bcd4cf8769
+                            Id: 371d69c9-f701-4db3-a7cd-6a9266b67318
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -4776,7 +4794,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 42730f39-2829-4695-a975-19c0e6f58c79
+                                Id: 744d366b-e498-4991-b755-52a2a4810be7
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -4792,13 +4810,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 7f51d2fe-a7e9-483d-a7f4-0529f7b47eb5
+                                Id: 067af17b-cd60-4ac5-9a68-e86facc4b71c
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 46de7a7d-17de-4845-8816-b48f52b3cdbe
+                                Id: 40bd9d6a-a113-4d1d-ba3f-14da7ecfe4f6
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -4808,7 +4826,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 11253ea6-6165-45a8-910a-0a747a3241e2
+                                Id: dab21a07-e8b0-4ce2-9fca-46752731eb27
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -4822,7 +4840,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 9e8171f4-2416-4ea6-817f-86bfd4b62341
+                                    Id: 971f31d7-4239-469c-a992-eb23e365d895
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -4838,13 +4856,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: b35f5e1e-cc0f-4b22-b8a9-b5b9a846e4c5
+                                    Id: 5fadcdb0-8449-4360-9c5e-3137ff4511dc
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 44a9ec61-a4cd-4c81-ad62-4d9f21d1a1c1
+                                    Id: 32bd42aa-adde-4293-bfff-8f8db3d5958d
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -4860,17 +4878,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 0f522646-1038-4fd2-966c-c2a928eed595
+                                    Id: 456ea37b-ada5-41d7-a01d-df038897a283
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 2931f04a-0281-4081-a1f9-1e6e4cd363f4
-                            Id: e4dbd335-aabc-457e-bb7d-a98450e7f361
-                        Id: 2e657f7c-939c-4d42-91e0-b71e1575aa32
-                    Id: 0b0ce8cd-11c6-499f-b135-fda574c67506
+                                Id: 764f3c09-f9bd-43fa-a261-8fb9e3fc54eb
+                            Id: e94ac52d-aaa8-4394-aacc-b3abf75c15e9
+                        Id: eaa5afe6-b042-4fe0-a2e6-7f26fe5388d4
+                    Id: 157de0ed-7c76-4441-8bba-71de32ae5e26
                 Id: 07685d25-03a2-461c-8a39-c33500cc514c
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated40x40mm
@@ -4879,7 +4897,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 34b38d08-1f4a-44ee-a688-2d8222c87b3f
+                    Id: fd43266d-f497-4ec5-9662-8aed6749ac56
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -4930,7 +4948,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 3b63c0c2-301f-4c29-8c79-f6c1e5a83f29
+                        Id: 05871996-2bac-4415-ad85-3c3e3d538b4c
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -4946,7 +4964,7 @@ Items:
                           Y: 1.25
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: eb8c80ce-7d9f-4ff6-b432-792f9a0449f3
+                        Id: 46002f00-1b66-4b42-97c7-2c1146ce87c0
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -4963,7 +4981,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 05bf709f-a765-4be4-9bd7-3474664bfd5a
+                        Id: 75fba6c1-18f0-489f-8ed9-119c61a22f19
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -4975,9 +4993,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: d8ced0e6-4026-459c-97f1-44d6bab9dd19
+                        Id: 74bf4a8e-ea58-41c1-a31e-7724ef54da9c
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -4987,10 +5006,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 63f69faf-e134-4721-a070-507430e8013e
+                        Id: b8974d38-b774-44e5-88c0-19c3b1f483ae
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 4ac3fe1d-c4c3-4b10-9fdc-6bfe2a583fab
+                        Id: b74bd59c-d236-40d9-abfe-2ba853d7e885
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -5002,7 +5021,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0871c323-d187-4ddf-b932-f0f524f2d94c
+                            Id: fbc8cfe5-0fa1-4b63-88c7-478eba1b5d63
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5018,13 +5037,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 6a412633-d9d9-4f0a-8fb4-df9b0e84a110
+                            Id: 76cc8281-73f6-46bc-9865-0f48e5deaee7
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 3e736a4f-4ffa-4252-bfdd-1852ce3b98db
+                            Id: 2e187318-b366-4690-88d6-4d0e4887093d
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -5040,14 +5059,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 68f80360-211d-4942-949f-7c82d5ce0f4f
+                            Id: 5a2c9699-3468-4608-bf11-6027b33d0b15
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 005d114d-a49d-412c-8b7c-b766415052b6
+                        Id: cbb8beb7-b6d3-4931-8617-f3703cc6b2b2
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -5055,7 +5074,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0d4ddfa2-69eb-411e-9370-4f52516ecaac
+                            Id: 2c26eca4-1317-47f4-9730-98c95fd870e5
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5071,7 +5090,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: cfdbacdf-9b59-43bc-bbea-db6381c72f13
+                            Id: b5c95e13-51c6-4c53-ae37-75099ed71466
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -5087,7 +5106,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 34cda1cd-204d-4cf3-bbba-a3027aff9d0e
+                                Id: 0750499d-c5d1-47d7-81f4-4342be93a538
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5103,13 +5122,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 69397132-f1da-49c1-9795-8ffa4558b7c9
+                                Id: 3ef2aa6a-943c-4030-a0b4-ce5939f17ec0
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 9bcb4876-75b3-4c5b-8ca1-639f66488306
+                                Id: 817c7597-a4d5-4ad4-b4d3-dd6c04dfad10
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -5125,14 +5144,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: b1863b1d-2a70-439b-b5ee-c717a15e64ec
+                                Id: 3756f80c-7e0c-46f4-9950-0ec3b3d07309
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 1e96b001-11cc-4200-b8a0-e50fe22b83aa
+                            Id: 74bbc4cd-6b78-412e-bec1-2077818d79ce
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -5140,7 +5159,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 9a9ee331-9220-42f2-90fe-a1dc88e40eed
+                                Id: 9a11fc74-5864-420a-adef-404aae9c7d3a
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5156,7 +5175,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: c5591970-2f5e-456c-be6d-16e932d09947
+                                Id: 7e701374-7fdc-4c3b-bd72-0ab161365dcd
                                 Color:
                                   A: 255
                                   B: 255
@@ -5180,7 +5199,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 8aebef22-efa2-4c35-b53e-ead6938eb543
+                                Id: 057ba0ff-6c8c-4e65-a588-3996dabdf830
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -5188,8 +5207,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: b73c6e77-91ec-4435-a9e7-b9fb02d0e3f0
-                        Id: e147bdd6-6241-4934-8ed2-15bd49bbdbe2
+                            Id: 1edb2ef0-d0ec-4ae6-88c2-9e00e6b1dd2e
+                        Id: 3849ac33-9117-46fe-967d-7251ce6100e3
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -5197,7 +5216,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 9140f493-e165-4c5d-b1db-bd3186b1469c
+                            Id: 2956a38b-c31b-458f-8ba9-769531af100e
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5213,7 +5232,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: d7a5fbda-27c6-46b2-96a7-0393d5df6086
+                            Id: 39fcb351-6655-4106-b3cf-933a8c75b79f
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -5229,7 +5248,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 190aecb6-ddf0-4378-b676-0582102c6e72
+                                Id: ab258f36-1046-47fb-b572-11c71ac0283f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5245,13 +5264,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: cda1cd7d-a567-4d16-8b70-df30e654bd57
+                                Id: 48159da3-7a36-4af4-ac27-9f59763c5d1d
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 2643bfc0-9b78-4c49-916f-1a06ed8fa91f
+                                Id: 365d7f2f-bfd7-4e93-a64b-b3fea3f1e782
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -5261,7 +5280,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: bd7ac89c-9326-44a6-926f-df12856a02a7
+                                Id: 5000cc36-594f-41e6-b929-3c4a6267abe4
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -5275,7 +5294,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: a1c4d935-5ec5-4476-a317-580c6c5d0e6b
+                                    Id: ce88b53c-face-43a0-ae87-f107bdc4a268
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -5291,13 +5310,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: f3f96b26-747e-48d3-9fa4-ba0043e4aaad
+                                    Id: 33a46890-12a4-4307-93a6-dc48daa05b0f
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 782c658c-e640-4a0d-8b91-7acd348d46dd
+                                    Id: 5a89b10e-f086-4666-a0ae-d01b52ed8a0a
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -5313,17 +5332,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 6dbaccb5-78d1-49e3-9ba6-6644b1223a42
+                                    Id: 285327f8-350f-4531-ba79-50ccd268ee8e
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 44b75a41-edc0-4e27-8c38-575ab485261b
-                            Id: de4aec27-58a2-4e44-9d6a-e66c86a7b465
-                        Id: 32f9377e-9fe3-4a77-9669-6d1f1227802e
-                    Id: 34e2aa46-3878-40fd-a36f-16490c173d65
+                                Id: 30604fc2-dd7c-4824-a9be-3bd512f07497
+                            Id: a2a1887e-bd3d-4025-87b3-3788a41ac368
+                        Id: 38b4cdf9-717f-4758-b8ab-d05774964884
+                    Id: 17cc5c88-46db-4090-8732-e8eb68bfa109
                 Id: 8e9a9a7b-8afc-4c0d-94f9-e1eff86d2e45
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated48x48mm
@@ -5332,7 +5351,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 7948f0fa-2174-4799-9943-ee311af03945
+                    Id: bc3ee47c-387d-43d3-8750-9bef2b26077e
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -5383,7 +5402,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 87479d49-2734-458b-bb9a-788050ed9cfc
+                        Id: 36aa3a55-d674-467e-8e60-a3ad9cad7f06
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -5399,7 +5418,7 @@ Items:
                           Y: 1.5
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 1b383c42-ccb5-46f6-9574-dcf02ce095c0
+                        Id: 18bdd657-6c31-46c6-9ee5-9e103ef9ab43
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -5416,7 +5435,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: bba93532-3472-4880-9b73-1fb3a4a8880a
+                        Id: 9e3843f3-d613-4b35-b5e7-73d35dc49655
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -5428,9 +5447,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 5f794f9f-bac8-4c53-8fd3-e0abfe9e1c93
+                        Id: 8e3ea638-3dff-427a-bc5a-be34b35a8be6
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -5440,10 +5460,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: c9e01116-b5e4-4abf-b720-9f2780b24f82
+                        Id: 474eaa20-6e73-43ed-ae37-7cd779f1644a
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 52321751-a155-436a-b9a6-3ce0117e64bd
+                        Id: 60904690-5e0a-43a0-b62f-767530e470f9
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -5455,7 +5475,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0daea3bc-89c4-4631-a0bb-8260bfbf549f
+                            Id: 1153d66a-c79a-4a30-ad2c-fe6a7e7d0028
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5471,13 +5491,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 56366d0c-0e55-41c4-afa5-ba0fea694c34
+                            Id: 54f78306-ae1c-4af1-a83e-3db6a6bb4dae
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 503ec310-21ef-44a6-bbf8-08d2f9f80b50
+                            Id: 69320ce8-f50c-4e97-a789-f5564c0ee39e
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -5493,14 +5513,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 62393d30-636d-4d35-8343-f3ba3184d794
+                            Id: 1e782e17-6aa3-484a-9857-5e2dee4909cf
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 1a013143-0580-4042-be57-e3bd3cc55a68
+                        Id: c7e7ac04-5e6a-4cff-9f84-1eff311f3a01
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -5508,7 +5528,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 254798ea-27f9-4d98-be1c-02fa19df5b2c
+                            Id: ff02e4f0-feee-4fff-b31c-b8de4039b35d
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5524,7 +5544,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 9f06985e-47fd-4316-8a9c-1f599061fcc9
+                            Id: 67d1922b-f652-4bbb-bf04-ed54a1ee35e9
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -5540,7 +5560,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 965ce283-357c-45bb-ad60-7c52aa43d746
+                                Id: 8e5807da-59d7-4bfb-90df-4a65456edd95
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5556,13 +5576,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: a8ba34a8-4a79-4a58-a4ea-3bb09d854660
+                                Id: 33848c83-1604-4f99-bb88-77ed8677f6dd
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 5f11e7b6-dc9e-4430-af94-84c46dbda40e
+                                Id: 34d308c0-00df-473b-ada9-9622d906ab7e
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -5578,14 +5598,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: f9507c51-f825-4854-a47d-1cfc56aaf6bf
+                                Id: d468ae07-df82-444b-9a4a-3c3bd84a030c
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: c3a3cf32-9c41-4b58-a451-119758c66f2a
+                            Id: 7202218f-455c-4a10-b39e-f18801c62d27
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -5593,7 +5613,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: f6b7ea13-5fd4-4eec-8bc2-ced59dfa04be
+                                Id: f362e268-71b2-4870-b302-d1cae46a9126
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5609,7 +5629,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: c5ca1048-1f3c-4ca3-abc2-0cb724420247
+                                Id: 5566b164-1e9f-4135-aa8f-11d65c087a5d
                                 Color:
                                   A: 255
                                   B: 255
@@ -5633,7 +5653,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 3fe12437-e88b-4e61-a9a4-90b38a97eb74
+                                Id: 4c7d820c-9035-474b-8eea-22cb4ec06d08
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -5641,8 +5661,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: e49b43ad-8799-481c-8312-36f60903073e
-                        Id: f548a995-6f8f-4a5e-9899-e2cbef7fda3a
+                            Id: af496e4e-e76f-4c04-8e5f-6d3ad25cd42b
+                        Id: ab4d6796-b5e1-41b7-b67e-75fda421ab72
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -5650,7 +5670,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: e1e33866-f39a-4e54-861d-7da6a9c983cb
+                            Id: a200462e-15d4-4aa3-b4e3-cbd04336e10b
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5666,7 +5686,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: e241fa98-b004-4cd6-8497-7642fa9d760f
+                            Id: b0a3e68d-7626-4089-a090-2d2656b71ea6
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -5682,7 +5702,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 2841b6ca-00d0-41c8-886b-b80d08846888
+                                Id: 74ca52aa-ba5f-4e90-9ec0-6da6e252a83c
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -5698,13 +5718,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: dc6a92e6-344c-4217-8d5d-b91e83dedf41
+                                Id: 045bcc39-a67f-420d-becd-98a0da6aebd0
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: c23fb642-8304-43d6-b583-3445efbc29af
+                                Id: 874dffd3-b7b3-43dd-9f05-af8ded26a2ee
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -5714,7 +5734,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: ad1e47ec-7167-40e9-a2a2-e7c214ba3f44
+                                Id: 59690f89-2f3f-481f-8552-54217569cd14
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -5728,7 +5748,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 19f53e02-f344-4b7e-aaec-89a23a8e0b07
+                                    Id: b1285276-3a6e-4964-92f5-869862ee2fd5
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -5744,13 +5764,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 76f7bf00-b4f6-42ab-817b-c2a63af5c0ba
+                                    Id: cdbd2b9b-979a-4d77-99d5-26d61e9edf65
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 2c2c8fa3-270d-4680-8896-39464c564b25
+                                    Id: 1d0bd56c-9c79-4911-aab3-0cab0e38d189
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -5766,17 +5786,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 15afdbad-4a43-4a7e-a2da-9523da954936
+                                    Id: 97921850-7bdb-45c8-ba1e-68b24e6c9af4
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: dfdb32c6-740e-4acd-870f-a700403e3b00
-                            Id: bec57e6a-db75-422e-8735-4b29ae497e56
-                        Id: 85ed19dd-3894-46f8-8029-cc0c92061f62
-                    Id: b418f26e-17c7-4b7d-b07d-188666e65b2f
+                                Id: 50841aa8-22ee-4cac-9d60-9a34e698798e
+                            Id: 99db5d14-85f4-499b-86ca-bec39699ba89
+                        Id: 1f03654f-42d5-4464-93a4-95b87b979844
+                    Id: 81e1baf6-c9c9-49b0-a997-b7ed2d10a0c5
                 Id: 8370b1c1-b776-4f09-9b3e-ed27b12cefc0
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated48x48mm
@@ -5785,7 +5805,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 9ea1aee0-8321-431c-88f0-6b83c4fc5c53
+                    Id: 53eb0b41-c807-4d5d-b55a-52dd29d6b920
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -5836,7 +5856,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 8b58924a-f5d6-48e8-9281-46d27a42214d
+                        Id: 3e71bd23-40fe-46a2-af04-9060d617f4f5
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -5852,7 +5872,7 @@ Items:
                           Y: 1.5
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: c7a3a5cc-4f8f-4c04-8c78-0813ea9ad7b6
+                        Id: d11489d8-c2a0-4be9-bcb1-4eece96c57a4
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -5869,7 +5889,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: b08f44c6-1be0-4bd2-8126-8ab7179acc16
+                        Id: 6afd5a47-3d1f-4855-b970-2226d48749b7
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -5881,9 +5901,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 33a5300d-6036-40b7-ad37-b664100e7ea6
+                        Id: b2fadd52-bc31-45d5-820c-0f878f09abee
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -5893,10 +5914,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: dfdb994c-32fa-44dd-9258-fcdc18f470c6
+                        Id: 7f641ab9-14ce-4cb8-a387-b1ffcb99cf57
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 0c2f6cdb-428d-4a1c-9b8c-5716a698b3e0
+                        Id: 8c89519f-fdfd-48a0-8d5b-0e9d2f9d8244
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -5908,7 +5929,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 5780b7cd-e9e1-40e6-944a-eee8d6dfcbd0
+                            Id: 4cd36cb4-930a-41ba-8189-a474be323362
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5924,13 +5945,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 3df6baf0-d3ea-4ca3-8858-645612d19afd
+                            Id: 57bdba38-7edc-4070-a566-df1de1e05799
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 65f2cc40-e13e-4fbb-8d28-835e500c49f7
+                            Id: 272abc5e-e515-4695-99af-aa96745480bc
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -5946,14 +5967,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 619577b3-05da-4903-b53f-141ef114d183
+                            Id: c29e803b-1904-468d-a287-914494661d79
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 131f12a0-ad4c-4ea8-8c1a-a2dd85daf23f
+                        Id: 341aec47-64ab-49c0-8889-7d3407f386a9
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -5961,7 +5982,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 62265fe5-8108-473b-95a5-0282d3097aa7
+                            Id: 586ce2e9-c61a-4d94-9aa2-851ff7fd2fdc
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -5977,7 +5998,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 45bb6b30-43a4-4b98-a3d7-cdeb6bf7c8f3
+                            Id: ee851737-4631-441a-820a-a28816b8e953
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -5993,7 +6014,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 570daeb3-ef1e-4cc2-9d06-05f15cfffa49
+                                Id: 73a15209-89fb-4309-b866-ddff7829bd48
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6009,13 +6030,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 1033f2e4-6ad2-407b-a233-8ac3c87aae93
+                                Id: d2ca8764-9666-4086-9c6f-9b8c7fe02307
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 1de9fefd-346a-407d-afe7-702dad9f9c85
+                                Id: 8e618294-ca6d-4f58-af76-74a60936be97
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -6031,14 +6052,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 4d51bd2b-89f0-4b4d-808b-64759654b797
+                                Id: 93ec20b1-271e-4829-9c1d-550dcc76ac8f
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 898b479a-d5c0-407a-bd2e-7d1514c656b3
+                            Id: 3b2f3fa4-dd14-484e-a827-5441041d5f10
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -6046,7 +6067,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: e6fa374d-72e1-4f2c-9a1d-d2a5ea7eb131
+                                Id: 21f4aef5-4ed3-48c8-8c62-f384b9de2f8f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6062,7 +6083,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 5800d473-3d52-4080-b0e5-4f24c8fa02bb
+                                Id: 7e9148b2-0e1b-4539-8523-0e659da2f869
                                 Color:
                                   A: 255
                                   B: 255
@@ -6086,7 +6107,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 9482ce05-ac54-4c73-b0dd-9f352e490868
+                                Id: 5c36f512-7db9-4d28-941d-b599c87f2439
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -6094,8 +6115,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 9e56fdad-9558-40c2-ab28-d9e2c9e9ef53
-                        Id: 9b2f385a-c515-4751-a555-4a2a7e7b90a7
+                            Id: 2ad4bf32-0ace-4b68-9803-f003184f9bde
+                        Id: e407ba0a-23a0-4051-acb2-90c2144d031b
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -6103,7 +6124,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 31accb72-5179-4bb9-9b25-2307a59c2f1f
+                            Id: ce115e61-7a89-43f7-b601-fa88bf3f99ef
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6119,7 +6140,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: aa51d283-5b9e-4ef4-abc5-f81069a995ef
+                            Id: 9bc729eb-cfcb-4a37-9ea8-74987961bbad
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -6135,7 +6156,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 19d82955-d436-4d83-9301-00b9e41aa30b
+                                Id: 79468936-2073-4e46-a1d8-82f613cd9ad6
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6151,13 +6172,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 5e909a7f-6ea9-485c-8fd9-917dcb16d78e
+                                Id: e92315ea-a9eb-4851-88a7-c4b7b2ecafec
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 54fd1b8f-0546-4f25-a4cd-d24d3b9e2a4f
+                                Id: 802e9da8-0715-41a3-9a1d-34d557719a1b
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -6167,7 +6188,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 99d065d8-14a1-4c6a-87ba-f9e593fb40ee
+                                Id: 7df7cf5f-aa7b-4481-be03-1bed4c712112
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -6181,7 +6202,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 09347da9-6185-4680-9d08-0ce55b2437f4
+                                    Id: b582472f-19d2-4826-9132-ba7e1032e17d
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -6197,13 +6218,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: c46c3bb8-0992-4c02-b3d4-d9a08ad702bc
+                                    Id: 68a3ce43-85c0-486a-9649-d90cd9da33ed
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 350bcae1-15d0-4f3e-91ba-4f375027c9fa
+                                    Id: de36de1f-5d2d-4235-86da-5221d0e649e8
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -6219,17 +6240,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 55ea86cf-24e7-4691-9233-9b571ff23d59
+                                    Id: a3dce995-4510-4d4a-b61b-a3edd4bdd6de
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 1e5b6402-fe1b-46f2-b634-0f9abc84594c
-                            Id: 20261b2f-d34e-41f8-884d-bfee942f6cfe
-                        Id: 2d075f90-1b7e-4993-bac4-00ce7a29b27d
-                    Id: 5b75cc7d-ddd1-491e-9fb6-d4b6fb4b20b5
+                                Id: ed63a1c9-6c38-494f-9055-cee19fe51d8c
+                            Id: d79a2ed2-e831-4877-ac5b-15d9af571506
+                        Id: 03b3902e-b84e-4c7e-89e5-d87b807e30f5
+                    Id: 17fd00c0-19cd-47df-a48d-e383dd050c29
                 Id: d5420c66-27c5-439b-94d5-4af726acf27b
             Id: cf260f8b-5d22-488a-98f3-c482b12c6228
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -6339,7 +6360,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 53ce5091-8c79-4f02-bf9d-588c62c53553
+                    Id: 1d3d6ab2-ede4-491a-bb1a-6cdf95f23f9c
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -6390,7 +6411,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: d472edc5-b029-4f7d-890f-60e8ba305f63
+                        Id: 429c4538-cb93-49ab-957c-4be5a69b9e35
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -6406,7 +6427,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 270efdde-8067-448f-b83b-8e084115329d
+                        Id: 00e869b4-329a-4f0f-a2a4-53c84e2baabd
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -6423,7 +6444,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: c217eb00-d574-491b-b23e-556ebf2dd1b7
+                        Id: ba41dea7-b469-4f1e-a5b5-5921e1ed77b4
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -6435,9 +6456,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 3a834cb3-cb59-47b1-95bc-95bf62746b5d
+                        Id: a26cbdda-551a-412f-87bc-e569a56f99db
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -6447,10 +6469,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 91b24b17-37f1-440d-9fd9-5c2168067792
+                        Id: f278b14b-f3fc-4a50-9b91-bee43ab53d31
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 185cdb03-4d01-4f5a-befd-be1d396f7572
+                        Id: 8eee8610-843c-420c-bc5a-c25a48bbe2df
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -6462,7 +6484,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0ed176a3-ddf6-46f9-9628-c44038e3a9ee
+                            Id: d5354dda-b6d2-4198-b879-13e4a35fe59a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6478,13 +6500,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 976cc20e-7de3-4993-8b5c-c4021b615fd3
+                            Id: 06674064-ace5-42df-9fad-9fb3c061bc4c
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: e4b6d279-a7e0-4994-a27c-8513aea3b86a
+                            Id: 14672f9c-bb43-426b-b9df-93ff690fb6c8
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -6500,14 +6522,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 2dd23ddf-6f88-4aea-b359-b52c3435c8f2
+                            Id: 1a7b6cca-2c0e-4a4f-b723-8e10a32fec8d
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: fe8f93bf-d28c-4b05-b376-59aeb567e757
+                        Id: ffbc83ba-205a-4bf3-b645-33ac3826ee93
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -6515,7 +6537,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 02bdca4f-f4fb-4d63-841d-0cdb575e15b2
+                            Id: aba0611e-228f-4b99-896b-0e9f1329a631
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6531,7 +6553,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: bfb5db7e-958e-4493-84e2-d4f76aecda77
+                            Id: d27aa799-f341-4c52-a22c-c67b3a59133c
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -6547,7 +6569,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 38a8ca6d-7e07-468a-87c9-df88aab9fb87
+                                Id: ea363c07-adbd-4a85-b896-4c8a8538b2ee
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6563,13 +6585,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 38dab6ce-eb03-483a-ae2b-476f157e0f03
+                                Id: def0fc7d-2003-4698-8298-6eba731218a9
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: db4f7d46-6772-43d0-b261-0a74042c429c
+                                Id: 3c9dd6b1-1ff1-4996-bf95-cb61f3b5bb64
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -6585,14 +6607,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 7f347cd1-83fe-42de-bfb2-202815c1dee1
+                                Id: 934a511d-abc9-4667-aace-cd97c31a4374
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 6ab6516e-373f-473c-988b-714f91ef10ac
+                            Id: ee6ad84f-435d-4a19-b5db-002def5141ec
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -6600,7 +6622,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 3dfbfc7b-59e1-4f1e-a96c-d06fd1846b59
+                                Id: 9d547522-b7e4-4cb7-a13f-d5e6c375f37f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6616,7 +6638,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 568f62cf-1c5b-40bc-b922-f605de6947ef
+                                Id: 2ef74553-eabb-42e2-8bd9-2e3a78fae2d6
                                 Color:
                                   A: 255
                                   B: 255
@@ -6640,7 +6662,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: e7d0a25e-863d-4335-95ad-53166b9968ac
+                                Id: 9762ea0a-8d07-4039-9085-1c83d103429d
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -6648,8 +6670,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: cc2701b3-2bfd-4f12-96f8-c939d6ae7c2a
-                        Id: ae9ebddb-4508-47c1-a7d6-18bfaf1bc37e
+                            Id: 1e27ca9e-aba3-48a6-b670-067fada86c5a
+                        Id: f6df3f90-fc42-4308-9242-bb4e0be03d51
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -6657,7 +6679,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: f2d8dfd2-ba7c-4760-989a-d417f9c73316
+                            Id: 516bcd86-686f-49d3-aa96-14cbfaceb8a9
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6673,7 +6695,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 91cd1d29-ccf2-4f4a-a9a1-d4e44785feb0
+                            Id: d25c5e49-8e91-43de-a2eb-8be8d6788099
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -6689,7 +6711,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: d8f9a343-e761-4963-8409-75aaf360adb2
+                                Id: 274a7c9d-cba0-4ef8-86d3-8d7b08d81cf4
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -6705,13 +6727,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: ee2fd738-e7c5-48ad-b78f-9fc92b3dcf88
+                                Id: 097a9467-4113-426e-a35c-2ac3bf6baf7e
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: a948707c-ed2e-4c8a-ab91-90921e67e7f3
+                                Id: 32c279fc-b74e-4730-9ca0-d47e1d6d1f2a
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -6721,7 +6743,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 92edc2a3-56e8-43c7-b8b5-cfa68ffaca2b
+                                Id: 6eb06ea6-8096-41da-9822-9ef5e095c120
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -6735,7 +6757,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 521bf6a9-7504-480a-93ef-d6ca47c5de7b
+                                    Id: 0ea876e7-cb70-4bf2-aced-3c6d2350d3fb
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -6751,13 +6773,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 98768e65-ad58-446f-ad14-17093063085c
+                                    Id: 4056ded5-8669-450d-9913-a3139eba5cf9
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 32a33b85-f9f5-4fa8-8419-9ce9d645cf76
+                                    Id: 44d43589-5d10-444c-bd7c-232a47eee7d5
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -6773,17 +6795,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 3917dc04-59e2-4e26-b9b6-7220c2ace7a1
+                                    Id: 82546a36-8ec2-4ff8-8ff4-47da648c9b84
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 5a8a3d02-ed02-4b9c-9d60-53170e2290b4
-                            Id: 3211a5d1-308f-4e92-a225-6b9acbbe75d2
-                        Id: cad1534c-3162-40b5-8bbd-9bee8722da94
-                    Id: c3bba950-9be2-4ec5-a935-02c8aa977773
+                                Id: 0b159fbe-25ba-4442-94f7-2d47af0182a8
+                            Id: 8c241160-0d5f-4581-83b6-131db4b9a71f
+                        Id: 36be4735-a6ce-468a-a32d-e9d6f81ae364
+                    Id: f82007e9-1a35-49af-9144-7af03c917644
                 Id: 5056cf9e-5840-4e08-9662-e6b9b7c44431
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated
@@ -6792,7 +6814,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: e15bf007-c9b6-4195-95b0-b14586d6d547
+                    Id: ee3288ed-f443-431c-a208-02d0ca73798b
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -6843,7 +6865,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 7bdd7eef-01dd-4c4d-a436-053a4f453bc8
+                        Id: 29b0e745-52f3-4f6c-82c4-62dea9666eb1
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -6859,7 +6881,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 40500212-3e25-43a2-9cd5-747e3df1e69d
+                        Id: 3b6141f3-67d5-4304-a3d5-2414ba735c19
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -6876,7 +6898,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 08ef7820-11f3-4aba-9a93-d8b6f2622253
+                        Id: 94e89b74-6324-4a72-b1cd-a6a0f501163a
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -6888,9 +6910,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: eb562062-563a-4895-92e2-c6ae9eae1b52
+                        Id: d18d6a2b-2f8d-4376-9017-e7c0b4281508
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -6900,10 +6923,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 9c1da554-2ab4-4a06-90bf-d0f8ca5d7810
+                        Id: 2bbcdf72-5316-4a6a-87e8-7c6cfcb11d1f
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 4ac83248-8169-45f1-9936-eec370b7fba8
+                        Id: f3489596-ef00-4b8d-8081-0be5de736119
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -6915,7 +6938,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: aa37d4bf-af61-4f2f-9163-aa5cba5d7fb7
+                            Id: f3ef5ca4-ae18-4219-9290-91db1c2dae8a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6931,13 +6954,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 4a140093-5893-4947-a59a-bba46cd71813
+                            Id: ee669ae0-e3ee-4b36-a509-e967b0ecd75f
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: cfa8e6c1-c0d7-41d8-95ad-26e9c051ffbb
+                            Id: 8cc48c9a-3ff5-47da-ad78-9c0dcbae8ebb
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -6953,14 +6976,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 4d0816a9-3186-49b1-862b-53f7893603f3
+                            Id: b24ede4f-f419-48d2-be0a-a01b500ea44c
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 1eb802cf-a9e6-4a48-bd3b-76b96bd0ed4f
+                        Id: 948da725-989a-4e85-be96-340db9e60baa
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -6968,7 +6991,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 8f44ab8f-6f11-428c-a59b-6a9fefa40555
+                            Id: 620b6337-562e-474b-804b-0e9e08ea54c4
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -6984,7 +7007,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: c94ee92d-f677-4cc9-b2d0-827a258ddf7a
+                            Id: e1950f9e-87fe-4722-807e-9e6dca1960f3
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -7000,7 +7023,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 4ce78cb0-f685-4532-b4fd-5187fe658142
+                                Id: 1df3caa8-4f59-4b26-b3de-05883c79f56f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7016,13 +7039,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 03a60feb-b725-45d1-89e2-fd3e6b80ec7f
+                                Id: 1dfa38ce-a8b5-4187-9712-455d0ec8d3d6
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 75feb31f-7fe8-41a5-b298-41540e322933
+                                Id: a4e1978d-7101-4ff3-b5cf-bc1edba0892a
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -7038,14 +7061,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 6194a303-dd10-44ee-b6e2-6514cbc79632
+                                Id: 35182c46-82da-4acb-b580-6e98783a63d6
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: a70b6f26-d2d3-473d-a781-943435fcb0af
+                            Id: ef92caaa-225d-4d93-8be5-2a02264c729a
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -7053,7 +7076,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 8a538d34-4e93-4e22-aad2-fe5399f11d25
+                                Id: 5c06ea9b-c8e1-4c7e-b42e-228109f7f1dc
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7069,7 +7092,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: efc930d4-587b-48b5-a391-27387a7a8368
+                                Id: 9a130e7a-e274-4f93-91ef-f08b3d4e7a25
                                 Color:
                                   A: 255
                                   B: 255
@@ -7093,7 +7116,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: bafc8fb0-c1cc-4e87-88b7-2416675f920d
+                                Id: a279a1f4-2221-4aad-9427-5f359463fa9e
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -7101,8 +7124,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 97da2188-189a-4142-a85e-4b319c67dfb2
-                        Id: 11527be8-8eac-465c-8d8d-f72ca4ff28c6
+                            Id: 196f442d-2891-4ded-a541-9fde794afd09
+                        Id: 962bf207-670b-4cf9-a73a-03b6dac0a91b
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -7110,7 +7133,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: cf795200-215d-466c-9319-673ecb478bfe
+                            Id: 2e9b8509-600b-4447-899a-9a348e09fc0b
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7126,7 +7149,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 6c6afb9b-2c06-4e75-8d11-2daac74053bd
+                            Id: a2d530a6-7544-44af-a118-b9e69efbf349
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -7142,7 +7165,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: ee3883b2-46d0-4797-b15d-86c93cdef28f
+                                Id: e35bc948-d6a8-488d-949f-24cef9cb8253
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7158,13 +7181,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 883733f0-eb85-48aa-b574-7abf6b69aa8c
+                                Id: 49a06603-1a50-4c88-8e54-7e87a209284a
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 289d2f4c-eb56-4f4b-a44a-c500d4981ded
+                                Id: 0ac609db-4229-4931-89e5-f68560f6ad2d
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -7174,7 +7197,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: de901c73-3631-454a-adda-c2f54a86e1bf
+                                Id: b144188b-6742-4341-83d5-aa152fce0afd
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -7188,7 +7211,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 55a540e4-7f8d-48d3-a78f-aaf510b13d9d
+                                    Id: 9eca2a45-0e94-49c6-8119-57828829769e
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -7204,13 +7227,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 9468e45f-e7a2-4093-a463-524880b75560
+                                    Id: 2f785800-85cd-4cc5-9dd2-2dc1b4767d25
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: d9915bad-32e0-4e1e-abe7-fe33061d07eb
+                                    Id: b3e3a9f0-4de0-4da6-9a85-61d2a5d9fed2
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -7226,17 +7249,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: af7b295d-041a-4a02-95aa-1bda9fc848bd
+                                    Id: f0991779-2170-47b9-b968-283f611290fb
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 67e9d0dc-43f0-4f9c-bbc4-f871beb53f3f
-                            Id: 3baee9b8-42ed-4608-9d43-ea14cfead0fc
-                        Id: 2b7fc209-2068-4d18-b415-9a40f447064f
-                    Id: 7774e5af-0f96-4a6f-ba7a-861d1a617510
+                                Id: 7703e584-a74c-4bd5-b98e-b89df3e4a1bb
+                            Id: d29d6e14-aba2-4876-962b-e237258c0bec
+                        Id: 62d4d4fc-63c3-425e-9fab-51f3ef45e49e
+                    Id: 13b490a2-02b9-4175-830f-4ddb162c3b1f
                 Id: a44f7a71-4aec-43f2-b09b-0a634b1f40f5
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated
@@ -7245,7 +7268,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 9fbd21f0-99e7-4e97-9793-9263191229a2
+                    Id: 2366c087-3cda-4786-a294-ca182b7c3c6a
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -7296,7 +7319,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 9bdbe968-1029-4858-bf3f-2adae39cb17c
+                        Id: 4e23273e-cdc2-4e0d-97b5-ed93024fbcdd
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -7312,7 +7335,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: ab636fe6-bdc8-421f-9094-2f63a4613118
+                        Id: 7fac4d29-63b3-44d7-ae68-882bfba1e632
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -7329,7 +7352,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: d96c387e-083c-4de6-85cf-e17fdad55bf6
+                        Id: 33aaefe5-ab94-476e-85ff-7795a153a30e
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -7341,9 +7364,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 386449ee-8064-438b-a221-1d998701fb18
+                        Id: 66dd1d78-0fa0-49af-949a-0e98b7b2aaa6
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -7353,10 +7377,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 4e793da4-e089-4c4b-b096-98f54857e83c
+                        Id: 15e4dc83-ecf1-47d6-924b-f5d62d438f9c
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 1a312557-88f1-4d6d-a26d-419c2ed8aced
+                        Id: d29729d8-d4d8-47ac-baaa-a5ff0260053b
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -7368,7 +7392,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0e814b3b-f3cc-47de-8f21-d7e051002dca
+                            Id: 0a641e93-42e0-4071-ac61-e8f5c0accc5c
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7384,13 +7408,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: b3d051c3-34f5-4ad3-b7dd-d253c23e3cea
+                            Id: c752b09c-0e02-43ec-8b43-940981eac1a7
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 2da69627-c901-4b9d-80fc-c1f1463df4c8
+                            Id: a1196690-20a4-49f1-bd89-6417a7f49711
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -7406,14 +7430,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: c4ed9567-8114-48ac-a45d-9ddeaf6c6224
+                            Id: 0983187d-7a21-4c2a-8aac-90938a0e9307
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 91181178-245d-43d2-bdf5-d8db3932f73e
+                        Id: 716675bb-c534-486f-80b6-7df031976053
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -7421,7 +7445,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 8a41c637-6886-445f-9480-3c2bfd0740c1
+                            Id: 61bda170-d9ae-4ad7-a012-4bbc08a8b3c1
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7437,7 +7461,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: d23ad954-1b0c-4ee5-aaf3-bf59b3c3a5cc
+                            Id: 2533d449-4547-4d8b-a164-f864bfc4ea32
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -7453,7 +7477,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 9b1c6192-5970-4ae2-ba0e-194db7930106
+                                Id: 0e05fd9b-31a2-4b68-b490-4ccc5bc90826
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7469,13 +7493,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 63ed5c1c-29f5-4bbb-a0a0-918832445d45
+                                Id: 3c4ef7e7-b548-409e-8940-4a0276d9f3fa
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 3c381fe6-1e9a-4635-9520-203066338d20
+                                Id: a7f5840b-d01a-4aa2-9261-89fe57875c73
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -7491,14 +7515,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 54adaf6b-725b-4097-9aff-83e978fe69c7
+                                Id: 634b85e9-e51e-4bc2-88c3-2695b5e9a2f8
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 224a3683-f1c0-4c9c-82a4-533468cba200
+                            Id: 747858cb-dcf3-4737-a05f-8e226e0d0084
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -7506,7 +7530,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: e98ef640-6ed2-4576-8a26-d15b6accfd9f
+                                Id: af05d644-25b4-40a2-bf4a-26f814ed24f3
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7522,7 +7546,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: aa22369b-7d41-458b-b98d-6875773201f5
+                                Id: 5e6d5db2-6466-4258-a961-2795d4556dfb
                                 Color:
                                   A: 255
                                   B: 255
@@ -7546,7 +7570,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 7fd5a360-b15f-48b6-9711-7fbb76f94180
+                                Id: abdd9d02-e465-4210-b05b-e184c37a97f4
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -7554,8 +7578,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 476badc3-1695-4775-9a96-34c0f20618db
-                        Id: dca56632-423a-4db8-a4a4-775500394d80
+                            Id: f475ceb2-82b3-429c-bf5b-731e1fd2eb41
+                        Id: 73ecdeb3-62b6-4c21-bf3f-a116bdbe0027
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -7563,7 +7587,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: ba8d7de5-c5d4-4917-9654-ee25a36c533c
+                            Id: 35800c92-3cd3-431d-bd9a-7e96cff24c91
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7579,7 +7603,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 52f5354d-06cd-43e1-93e1-e2289e803a7c
+                            Id: 10b21111-8c6c-46f1-bcb9-4b878d206e9c
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -7595,7 +7619,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 214c22ad-0518-4de4-a5ac-9c48036db415
+                                Id: a88a8afd-3436-4ac8-ad63-dce3866e5e57
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7611,13 +7635,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 46104f26-bbaa-4c91-bbd2-97293ec52076
+                                Id: 5c86631d-12a5-49a6-bb7b-4376155058e2
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: fe8fcebc-6deb-454f-99ef-cddd2deee1ee
+                                Id: e2ea7be0-94f1-4c0b-bfc2-785a25600c66
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -7627,7 +7651,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 1969606f-4545-4720-b910-893a33683015
+                                Id: 8597b266-c466-4d63-b211-af4862a0a10d
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -7641,7 +7665,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: f7620199-8027-4f99-a586-0c21d33b8876
+                                    Id: f4adacd7-8f13-42bf-aeb2-c376df083fc6
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -7657,13 +7681,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: d0847f9a-60ff-4de1-811b-dd368aa64137
+                                    Id: 29e55b12-50fb-4d91-ac43-a009fc9dfc10
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 8b4b05aa-ba1d-4617-a9d2-1749d2b5b8cf
+                                    Id: 361aba2c-a839-46a7-82dd-da35755bfa5c
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -7679,17 +7703,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: c18ec891-b737-4189-8200-0a1d2271cd71
+                                    Id: dc2951f3-3662-41d6-92cf-679fdadff6f6
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 82e793e3-363d-4524-aa31-ef27da2d78e9
-                            Id: 94ff38f1-fe96-4433-ac61-026e23c8500b
-                        Id: 92986d3f-966d-40f3-aa8c-057e87f5b123
-                    Id: 1123a9cd-4328-4a4e-abf4-46e3de1d045e
+                                Id: de909a8d-ddbc-47de-809f-f9672e4d33ed
+                            Id: 61810db7-49e7-4596-b508-69dc7b6954e2
+                        Id: d5505821-0325-4e49-9050-5edf09ea2c9e
+                    Id: 03b77efd-9b8a-4083-9560-124569a3ddb9
                 Id: e7a8bb52-4590-47f5-8d5a-cf0316c846be
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated
@@ -7698,7 +7722,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 7e6d0ede-6d42-4423-82a2-7e9e18b173fe
+                    Id: 0dfd81fc-433e-4425-a0de-aa206e05bfdb
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -7749,7 +7773,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 0d3ee624-a655-42a4-9448-9cfa14e06167
+                        Id: 36ace80f-c8f3-4983-a96a-51c6694c254d
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -7765,7 +7789,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 553e8765-bd1b-4f26-b085-b7a4820b08fb
+                        Id: b0ad643f-5a14-4871-9f4b-440abd8b32e6
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -7782,7 +7806,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 9cc9a791-5c40-40f7-8ff9-5d345567fce6
+                        Id: db0f9935-875c-40d0-b330-42aab9005252
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -7794,9 +7818,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 18f18558-71f9-435e-85b2-f266d177ff78
+                        Id: 7c5dfac9-42f8-40ed-ba96-4c10b2cb3c6d
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -7806,10 +7831,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 4ab331ea-a7ee-445d-9efe-c3e43b1a2a70
+                        Id: 9ff3b34d-dcb4-4a61-ac14-8074921f6b26
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: f5aa2a82-618b-4238-9bbd-dbdf50c6bf16
+                        Id: 607ec1cb-f27b-44cd-9267-3ec22661b93e
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -7821,7 +7846,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: f2ac4057-e1f3-4706-ba35-461b3eaa705d
+                            Id: c73b3620-9b1b-4513-a2a1-cecfb78e8b0a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7837,13 +7862,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: fe5c6163-e16e-47b2-9eb2-4e10c69d4e40
+                            Id: 6a713755-10d6-45a1-823e-087d2c15f1ae
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 864ddec0-f3fb-4f3f-aa27-71e543062288
+                            Id: 44931ed3-f0e4-42ed-92d3-fe4cfe778b34
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -7859,14 +7884,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 4f10f670-2273-47ef-99b7-d93145e5b35c
+                            Id: 151d7032-f4c5-41b6-8ec3-aac4500acf12
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: b89c4894-878c-4a8e-91f2-5cac6c24b53d
+                        Id: a1f58148-744f-4253-8582-61baf6094b6f
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -7874,7 +7899,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 41e22e45-7711-4ab6-9f61-409de1dead1d
+                            Id: 84ee661a-d437-428e-8bb5-bec2b95692d3
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -7890,7 +7915,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: f7657c11-63b8-49b6-83d3-fc760026c31f
+                            Id: d6794325-ad46-4147-8b58-16794f74cda1
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -7906,7 +7931,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 255186cd-cd51-4538-9bbb-3397a1b2e12e
+                                Id: 32a4231e-6ff8-4f62-9708-f5122b8983d8
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7922,13 +7947,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: b8c0f305-be0e-49be-81fd-d96db3881a24
+                                Id: 254553e7-bde4-42bb-9942-b883caed7e72
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 163a35b7-72c2-41c3-8116-2b44e8a79394
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 3f6717e1-dea8-4ed4-af98-72a6cc88e655
+                                Id: c14c49ea-1949-4664-b8c6-a59ca9cfbd5d
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -7944,14 +7969,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 9aea6654-bb45-4df1-ba2f-36f6f1eb211a
+                                Id: a3a3c78b-7f0e-4b70-b1c9-0bc4f695640c
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 979d50f7-0a93-4197-aede-0b3df60a552b
+                            Id: d127b047-5dc9-4453-96f0-c3cde2b376be
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -7959,7 +7984,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 6b96ef4c-479b-4609-b7ae-112faa330be8
+                                Id: aee3b6a2-6820-4094-994d-dc0c990e9f00
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -7975,7 +8000,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: f3160428-266c-4f14-94fd-9edde467119b
+                                Id: 175c8fc6-eac5-4c2f-8d7a-a7026d0391c8
                                 Color:
                                   A: 255
                                   B: 255
@@ -7999,7 +8024,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: d2608ab8-7cb4-475c-87fd-ef16dc433577
+                                Id: 265575a8-ee83-4fc0-b86a-46f40be7660e
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -8007,8 +8032,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 2e14b274-4d25-4f0f-9c8b-4fa907020e7c
-                        Id: 355a7e44-bf9e-4a7a-b449-5145fad7934a
+                            Id: 4aca349a-a275-452c-9d16-630377844491
+                        Id: d32f307b-4c8a-4e8f-8f8e-c3eb97b5e499
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -8016,7 +8041,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0802cdda-e9f6-4aea-8d18-284add8bc03f
+                            Id: 330b70b1-3a70-4902-a2ab-ac7f09ea74e3
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8032,7 +8057,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: f49fcc4d-ef68-4675-9035-b4d2bb84f30d
+                            Id: 2ca29b6f-5ba2-41ba-b86b-8a429ab4d3c9
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -8048,7 +8073,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 692265b0-e509-45b5-a401-be0d80685727
+                                Id: 6ce3ea5c-67e7-4695-ad53-24b17f09dbb8
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -8064,13 +8089,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 65ad3884-70d3-4698-be0a-a6d169029808
+                                Id: c4d4cf3e-b124-443d-b984-401ac738bb11
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: b1987be6-9eb9-4e67-b603-461f22805871
+                                Id: 5ec3c4cb-3112-4e29-9b46-7866da5af78c
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -8080,7 +8105,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 2bd0606a-a626-427c-909e-e19b2bb7c388
+                                Id: c43abec2-7f42-49e8-92e4-4a4689944193
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -8094,7 +8119,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: ceb77191-51d7-4b0b-90da-587dabc73943
+                                    Id: d187993e-92b6-428a-a3ab-07e2c77526a8
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -8110,13 +8135,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 36da7a97-ffff-456c-b3b9-538fae4be7f3
+                                    Id: 2ec5b942-b384-4ea5-90f4-02274841a104
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 1a4f6868-d7aa-41a0-b111-f659a7a60e69
+                                    Id: 4378c989-28fa-45bf-ab5c-562db138d37f
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -8132,17 +8157,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 2bb2983d-3c98-4a60-9e24-3598e20593cf
+                                    Id: 203d6a6a-7f86-460c-a3c3-91f22c7dab29
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: dcef0a2f-6060-4104-9b9d-9f483d35846e
-                            Id: 8f639b93-5828-4bbf-a9b7-5da52affcb1c
-                        Id: 17ee904c-6f09-421c-92e9-a6abb511483c
-                    Id: d197a4e7-55b7-48c7-b13b-4cc508ec48cf
+                                Id: 0e8e2dba-8bc3-445d-ad7c-7de7a0ab1be5
+                            Id: b1bc8e2a-be1a-4706-a35d-dc21cf8df8a5
+                        Id: c1953dc7-4664-4e82-8863-a2425a653fd5
+                    Id: 85291f14-354f-4f54-887e-71e685ba5069
                 Id: 433c5288-c9e0-423f-a499-652673ac6f60
             Id: 3b5d2bca-fadf-4628-8931-9e8f5e344acb
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -8252,7 +8277,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: e70f25f1-86f5-4e3c-aaf0-a7d88baa5c8f
+                    Id: cc179cba-452b-4cb5-9da8-b1c21a0d730b
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -8340,7 +8365,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 367253e8-8883-4a23-9b90-762d0d9d3022
+                        Id: 990774a0-6ac2-4d74-b4fc-936e36836cd8
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -8356,7 +8381,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 91d418dd-b974-4f60-86e5-6d640b126618
+                        Id: 31836429-1f54-4ccb-ba55-6ae2989bef89
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -8373,7 +8398,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 8efe5ac6-9873-4f60-9a55-b6559a7894be
+                        Id: 9fbc572a-010b-481b-8d61-7562f5646f60
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -8385,9 +8410,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 898fd265-595e-41f0-98f7-5984d777d785
+                        Id: 766ab9f5-a74e-4f07-8711-5370d77aab12
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -8397,10 +8423,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: bcc3cbf9-a010-489f-8f62-d28f2ded4d90
+                        Id: 59b5e935-93d8-4be6-8808-eaa303670d93
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 23d92bfb-edee-49f5-8852-2a8813ee360e
+                        Id: a9a3fb7a-c2df-4b2e-ad86-8749ad647157
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -8412,7 +8438,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 1c85dbb5-ca74-4617-829b-416b440a03af
+                            Id: bd3be90e-d4f9-4a8f-a79c-06c68055e9b8
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8428,13 +8454,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: b260842f-7d6b-4b21-a32c-777bd41982de
+                            Id: 775dc0ca-661b-4635-b08f-e9e9128af6cb
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 6382df76-1485-45f8-b4df-942f044c4a27
+                            Id: 0e1b8e9a-0e16-4bb9-84f9-e2f7f64f3928
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -8450,14 +8476,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 5880f8ce-121f-4ac0-8239-104925e999b7
+                            Id: 20bbbb1f-29bf-4d2f-8c41-fb3a36194d03
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 1d8a9f9e-9e61-48b6-a181-a601bd20a6bb
+                        Id: 46227038-cd78-4aca-a4ce-bd121a696fe3
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -8465,7 +8491,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 2ff9fe1b-7e52-417e-b6a9-b8c11f4bfa10
+                            Id: 39a0a707-3290-4de3-8342-21d5f02c4998
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8481,7 +8507,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 4a664c3b-079a-429f-87f7-bca1d392a3bc
+                            Id: 009ce4c0-df0e-4425-8be2-a6241f10e000
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -8497,7 +8523,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 0bd2ffaa-3719-43d2-89a9-435f70b426b7
+                                Id: cb912e42-e4d5-4802-84db-2258ea1a48e8
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -8513,13 +8539,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: a4313f95-6759-4476-a7ba-0d16090c35d1
+                                Id: 33baa22a-a8b0-4d8a-a639-245c5bbafef8
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 7a93b9b7-56a3-41f1-8392-0751355e1bef
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: af49628c-6124-4f56-afd3-aaf1fe9b0dc7
+                                Id: 13d37013-a30e-40e2-832a-67646e5a99fc
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -8535,14 +8561,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: cf784217-74a4-4da2-bd9d-afb0110b6ab1
+                                Id: d0b59dfa-325d-434e-bfb7-2d2c5dfbd93d
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: ace4c52f-ec19-4136-b06b-8945f93f39be
+                            Id: a7d9f5d0-d7e5-4787-98f1-6bc06b72175e
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -8550,7 +8576,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: e11b9813-f7ad-4d29-930c-70f89d519983
+                                Id: 9c043ef6-1a94-495b-bb2c-8038d2b13fd4
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -8566,7 +8592,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 12b0fb20-e5bc-4fc6-97ec-cd1f72e25806
+                                Id: 4b16713a-585d-439e-bcb8-488dd336c162
                                 Color:
                                   A: 255
                                   B: 255
@@ -8590,7 +8616,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 5cb33a82-71cf-444e-b7cb-62f536006fd3
+                                Id: 273ec2c5-115d-4828-acf5-90b8b9b93ca7
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -8598,8 +8624,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: d1241cce-946c-4a2f-a757-e1627fe6b681
-                        Id: 994a9c98-2bc0-415a-b594-192959abb726
+                            Id: 50a8c9d7-d174-4270-b40f-81e0c51281b3
+                        Id: 4381cdbb-82b3-43ae-9117-3c1a54b885f8
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -8607,7 +8633,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 05b39b4d-a142-4511-a0be-d156c1665611
+                            Id: 8bf8edca-b35e-415d-b669-5b52a32b7761
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8623,7 +8649,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 9af8a79e-3ae6-46e8-b695-28ee3f0fc04c
+                            Id: 92d2df8b-a9a9-4d3d-895a-1a613b29ad9f
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -8639,7 +8665,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 03ff41ba-d8bb-418d-ae55-8a2bfb41b180
+                                Id: b02ec352-7076-477e-9d34-d2199ef58ead
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -8655,13 +8681,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 703ca7f1-3d81-4786-bb65-0806841bb83f
+                                Id: 0289dad5-1113-4b16-8c63-6210b042eb14
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 03bd5d9a-e93c-45fe-8a85-72dca63681a0
+                                Id: 8291acc6-5358-4581-8afb-d9e19e5c4178
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -8671,7 +8697,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 40a540a9-f6a7-4952-b4e4-2cb4969603f1
+                                Id: fbd46b31-b1d8-499f-9084-1ed4a05fbe24
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -8685,7 +8711,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: ec0b47bd-1f00-46ad-91d1-c5f8ac032678
+                                    Id: bd4ce2fc-fe78-4d68-9709-bb01fcd1f0a6
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -8701,13 +8727,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 4136a2fd-042e-4c50-a17f-38e30acb6315
+                                    Id: 83e4a852-03d5-4468-a51e-a3e7585b7e4a
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 98ea5ddb-b4b3-4056-b61a-d036272c381b
+                                    Id: 6e3072d7-82c2-4d61-8ae4-ac6650fc2df6
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -8723,17 +8749,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 420430b5-de00-4f47-8890-c14228f2067e
+                                    Id: cb9edb25-fe93-48f6-86dc-fd9ffec8bb47
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 1f9c1ed2-48c5-4c57-b65f-a3459d9d68a3
-                            Id: 8593d061-a249-4324-b7cf-6ab76c5a29ae
-                        Id: 6bba0e35-1e02-4692-a004-91049a5fb97e
-                    Id: dffc0738-6393-4b6c-95b1-e4e0947b3d70
+                                Id: 93466ce8-90dc-4ea3-bff6-bd50dfebbd65
+                            Id: fe65563d-a6d0-4404-98db-e04a72176cb7
+                        Id: 192da1c5-2f05-4495-a505-65d9504e26c2
+                    Id: 244e7e33-a978-40ab-a3db-24a1f1fa4740
                 Id: c7326431-7d6a-4b96-8583-9b09d9dfde4d
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated
@@ -8742,7 +8768,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 60919a6b-c25e-425a-8a73-100ad236f312
+                    Id: 2ea7ad4a-6fd5-4349-aaf4-56a398fb705a
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -8830,7 +8856,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 239782cd-6f6e-4e39-a84d-79bc91b68d67
+                        Id: cea77bd8-a994-4c5f-8284-39d70916fe63
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -8846,7 +8872,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: d00f8c40-f4dd-493e-8188-7c94b7021825
+                        Id: 556c1b80-cd9b-477f-8c25-9d6d601d3fc7
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -8863,7 +8889,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 378abe90-ddef-4890-a6a9-2f6cd10fd1e7
+                        Id: 98254ed7-8b2e-49a4-b0a8-47421d7001bd
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -8875,9 +8901,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 4e514432-6b7e-402a-a595-3e89931740d4
+                        Id: 708f815e-261b-4e2e-9215-9df62022b59d
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -8887,10 +8914,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 9dd3a3cd-b2b5-4cc0-b54c-1beb18842c59
+                        Id: d0a2795a-8c74-43cb-b8fc-42a84e36eb3e
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 63f8e378-397e-4987-ba50-c4645bae7928
+                        Id: 7d8ca0fd-a744-42bd-b31f-a761b58ea6aa
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -8902,7 +8929,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: cbf8ef25-4829-4ef1-b816-d997f5fd7e0c
+                            Id: 3b6b1aa5-552f-4085-a9e6-0d2eff84b32d
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8918,13 +8945,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: a8b9221e-57b3-4997-8471-6f0962f45064
+                            Id: 508ac9c3-f869-49e0-abfd-27c2bdd2b21d
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 8875f808-42d2-460c-b458-14819d12aac2
+                            Id: 9e1344d7-a747-4290-b272-5814acdcfff7
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -8940,14 +8967,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 955e8053-6029-455e-908a-df898e6a7c2a
+                            Id: 139283f5-ea77-4099-91c9-4d7cc52c8bac
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 60ff11ce-5bd4-43bc-bb7f-f8206d5c60d5
+                        Id: 108614e4-e86d-4dfe-afe5-77bfeac900c5
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -8955,7 +8982,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: df75a6d0-760b-4154-a040-3d35a6743685
+                            Id: 9e5ef489-1b0b-4aca-92f1-6c1166e8b2c3
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -8971,7 +8998,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: d680a178-a885-411c-afd5-d883fcb72227
+                            Id: c50e9c38-e902-4ff8-99f3-bc13728f5bc3
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -8987,7 +9014,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 57c8dfca-1332-47e1-bd08-6ad23ae99a73
+                                Id: f9bb3ae6-30a8-45cc-b55c-9c34ca823462
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9003,13 +9030,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: f0ad28fd-460b-4888-8297-a143e569929b
+                                Id: e63d01fc-4c18-40f9-83bf-d40d7048f36c
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 7a93b9b7-56a3-41f1-8392-0751355e1bef
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 9e4db9b1-c92a-41e3-a8d4-e4973470baa3
+                                Id: b353b67a-ddea-4a6c-b570-f6300abf421a
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -9025,14 +9052,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 6b68fe31-06a4-4d52-a8ca-7bab4008ecb2
+                                Id: 12467a53-34cc-47a6-80dd-819737b2f680
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 4a9b7c13-86ff-4c4f-b369-302ff43d9343
+                            Id: ec18b6b3-37ca-49cb-a1e7-4e515a797a5b
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -9040,7 +9067,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 8392d463-c8c0-4ad6-9618-cc4b7a9c01b9
+                                Id: 87ac7165-4e19-4d2a-a343-7da3f1896b83
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9056,7 +9083,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 4869a93d-a2cb-41d0-8d34-764054d76a65
+                                Id: e8847e72-3bc3-46c2-88e9-ec7b1aa77ac9
                                 Color:
                                   A: 255
                                   B: 255
@@ -9080,7 +9107,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 0bfbbbe4-e606-4e2d-ba64-793fa70d423d
+                                Id: d7f7e83c-78ac-4e8b-ab8d-5c6b0125ac69
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -9088,8 +9115,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: c817d842-c734-45bf-9919-2ba079b807e5
-                        Id: 835e9f44-63a1-4c5b-83d4-342dfb5fad8c
+                            Id: d05ce6d5-d56a-4216-8c08-ad0575be929e
+                        Id: 4741aa6d-2412-4a73-8b0a-45a1384d76a8
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -9097,7 +9124,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: fe5d0559-2904-442d-addd-ebe64bef6b22
+                            Id: beca6c11-1b68-47ec-8aa3-5beff5d9eed3
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -9113,7 +9140,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 32c61752-963e-4223-bc24-24eeda883c23
+                            Id: 22c9353c-16b9-4c34-a741-ef7248360a8b
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -9129,7 +9156,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 3a5a5264-4494-41dd-baca-5fc009272822
+                                Id: c5797616-44a6-4bb5-a7aa-c0e1eabfd6f1
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9145,13 +9172,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: f00d4b55-1c4f-4060-bad0-23df206a72c3
+                                Id: b8c5c849-6c4e-4906-85fa-f35c61029373
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 404e4d6c-c7f5-474e-bda9-c9f35fd8dfdd
+                                Id: e9d550ba-8013-42c9-9c38-ed33e0c22ae4
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -9161,7 +9188,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: c8693ea6-712f-4fb7-8aa8-2af27734e140
+                                Id: 80ce893d-99ac-4660-90b7-40f916a3ac27
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -9175,7 +9202,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 1e7c9a1e-9662-44a1-866b-a6cd8f7c0bf4
+                                    Id: 4f7c7943-2936-4751-89e4-a992a7c33e9b
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -9191,13 +9218,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: adcc14ef-69c9-4cb8-b3e6-d34afc9406f8
+                                    Id: bb05bdab-d6f4-4ff2-9f2f-5625723ddde5
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 63d16b0e-a6c5-407a-aac4-deaf37de850c
+                                    Id: 82cb16a2-2710-44c3-b54c-6d648c290a1e
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -9213,17 +9240,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 78e07db9-e5f6-476f-8ce9-3726b92fa634
+                                    Id: 8f47b45b-9aa4-439b-96bc-db8839658708
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: e26dbf82-b501-4d3a-b1ef-fe5c178f75dd
-                            Id: 955acf05-5199-4b77-aed4-4697fc55e521
-                        Id: fae5f095-cb42-41ba-9506-b449f8f3b7ac
-                    Id: fcc35085-adee-464c-9ce5-bd6cfd82e9c6
+                                Id: 38ebe7d1-a9e0-4a64-8870-1b79f3a77325
+                            Id: 3f5efe55-1504-444e-9896-4dc31a77b6ea
+                        Id: 12cdfc5f-42f7-4758-bc0f-e692158dca1d
+                    Id: 8df9667c-f46f-4899-be07-e9fe54233b4b
                 Id: ebb58b20-b972-400f-9748-209d37c06429
               - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                 Name: PressableButtonPlated
@@ -9232,7 +9259,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 19da4493-0d53-4b38-9baf-d7e1b900ce16
+                    Id: c7b4e347-fa75-4b8f-9e02-0a2309521826
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -9320,7 +9347,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 801474a7-8aea-4482-9800-11ca1dfe7e01
+                        Id: 6fb396f9-1587-470d-a1b5-abd57cbb2926
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -9336,7 +9363,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 24a738c3-9040-4c6d-986f-c7bad2aec672
+                        Id: e074356b-a6ce-4005-b5db-9832f677c150
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -9353,7 +9380,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: ae706c9c-644c-471b-88a9-0564c0c65d05
+                        Id: 13ebdfa8-a5d1-4c1b-9f5c-52ceac9d8548
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -9365,9 +9392,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: b0d75309-b8af-4642-b9e3-fa07f30cba5c
+                        Id: c79be421-7d65-4353-a212-4cefff67ac1e
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -9377,10 +9405,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: 07f0f94e-85c8-49a0-9fd7-d9f9ac523b96
+                        Id: 3c8feae6-7f99-4b01-9a4f-20527075cd58
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 2ad320f1-bec0-4bc9-8e21-ae32544459db
+                        Id: 65c9aaa0-37d1-47f2-ac21-9b68388bbd99
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -9392,7 +9420,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 8526d4ef-d4ac-4377-afd7-b1cec76bb0d3
+                            Id: f5a3a911-b1d4-49a7-8681-fcbbf39ac577
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -9408,13 +9436,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 50504774-2eb7-48fb-99ed-eeb8f88a4969
+                            Id: 5afe4120-d353-4e57-b428-277747ef546f
                             AsignedTo: Default
                             IsEnabled: true
                             Material: null
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: fd7a383a-ff69-4f98-b56e-8cdaf44c5ec6
+                            Id: adc0e950-83c6-4f99-9b83-07ff1913898e
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -9430,14 +9458,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 133b74e8-62a5-403d-960e-4a9a33bd47a9
+                            Id: f71f0805-7c98-4fd4-8345-21d7f23f3ec2
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 976e823b-1658-4eea-8042-1546c98c61ac
+                        Id: 397d6c34-cac1-4aef-ab34-40c2c502d918
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -9445,7 +9473,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 2b99901b-0d6e-44e5-991d-d1b7e043c7f5
+                            Id: 8b780d0f-0ec9-4cfa-a750-0e304bbcc7a7
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -9461,7 +9489,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 8d847d53-552c-4b20-8002-554ea16acf96
+                            Id: d7451e02-0951-4026-afdf-2fc71a70fc90
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -9477,7 +9505,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 7c1ec85c-44a4-4fe2-9407-2e9aecb0a915
+                                Id: fab62db2-94aa-4b06-89ae-a74f972e219b
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9493,13 +9521,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: a9445012-c88e-4065-b255-1af77e959d9a
+                                Id: 2dcdfa31-faf4-4dcc-9a29-7ed6d01e49c9
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 7a93b9b7-56a3-41f1-8392-0751355e1bef
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 0924e703-104d-4975-92e5-6865c18a8685
+                                Id: 9d9a3fee-12f7-4687-8968-deec1a3b7d34
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -9515,14 +9543,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 2dd7468f-ccbc-4749-9d37-9d23b56f479a
+                                Id: 4b67deb7-2f3d-408a-a30c-c07e39f82d6b
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: a6b9c15f-04ac-4af4-b324-2c07990e6aad
+                            Id: 8c437bd5-b037-4315-a29c-aafbca6cac32
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -9530,7 +9558,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 4729deff-1621-4eb7-8d98-2126b4ef4b4b
+                                Id: 13167de8-6c6e-4538-86d0-8a220c83d8c4
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9546,7 +9574,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: d59bbc4b-1e92-4680-893a-65073fd71550
+                                Id: 8cfb4852-400a-4df2-b942-1724919f05ef
                                 Color:
                                   A: 255
                                   B: 255
@@ -9570,7 +9598,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: fc5776c6-66cb-4bd6-bf1a-6a26a8ba5563
+                                Id: f0173370-a4ec-4a9f-a2ac-5ba5d9e45c01
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -9578,8 +9606,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: afd742ad-3053-490a-bb32-c66c6316b88f
-                        Id: ddf35639-c4fa-459d-b767-fee13508d743
+                            Id: d238ba35-adf9-4121-9155-d54b63a5ebb3
+                        Id: 24d91781-a8fb-4282-b42c-ff86af66016f
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -9587,7 +9615,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 5b78ab73-24b0-4a01-8a43-45bd8c78ae8d
+                            Id: dce91754-c9b4-4dbb-86a1-2f7b321a83c6
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -9603,7 +9631,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: d168322d-ccd2-4e3f-bedc-3b05d12d20b6
+                            Id: 6fd87f23-b5c9-4a2e-ad0f-30ca5a612f9a
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -9619,7 +9647,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 8d0b13b8-37ed-475b-a6c2-56e038ef0f76
+                                Id: e8e73127-80df-4f97-b61b-ac13ad34e2a1
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -9635,13 +9663,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: c7ff54da-092b-4e22-abca-2c29c2e75130
+                                Id: fd184186-41c4-4a1f-93d1-8740ff53f3d0
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 55ccc488-efe4-4bfe-af2b-f648b16a8b21
+                                Id: f1299eeb-8ef4-420a-873b-505d43700254
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -9651,7 +9679,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 18b025bd-ff6f-4331-a178-06daef2c4bd5
+                                Id: 7d615598-463c-4577-8c43-7736a7dc3404
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -9665,7 +9693,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: ac316b59-b3ea-4883-b534-4c32427962b4
+                                    Id: ba8db373-564a-4b3a-baad-e7f7122de724
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -9681,13 +9709,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: 764ee703-8c88-4008-9598-6e22e0281bb7
+                                    Id: 259f99f6-d552-4ecf-bacf-7feb2fd4dcca
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 8c493aa0-b5d8-43aa-afca-e3ebe1bb63fc
+                                    Id: 456d6959-02c2-4438-a549-d4b4f8e651a4
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -9703,17 +9731,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: fe6c6875-f181-41b7-8feb-c1ac899df50e
+                                    Id: 9dd2d795-8b95-4c35-9f6e-b72c104b2ebe
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: 7fa66a8a-3bde-44e4-8f2a-5b15bd27e6af
-                            Id: 731e546d-9e18-4893-87e1-543663e82754
-                        Id: fedb46d5-6b39-4806-ae9d-68fa889e4f8a
-                    Id: afc004ea-f97f-4ea8-8978-4851e242e594
+                                Id: 00eccae9-d956-4a34-8d01-579e88e35553
+                            Id: 87d19a22-4c43-4d90-bd3e-b556ddb73bd7
+                        Id: 205d3b0a-686d-4f86-8529-54ad7acf9d6d
+                    Id: 454e7d9c-12cc-4883-b226-b3991f6dbcd2
                 Id: 39869133-e8c2-4c7e-b8a4-0db469fb8754
             Id: 24812237-5896-4b61-acc4-a5d844be7534
         Id: 47d72413-3506-4620-bb70-f7a391fa8bd1
@@ -9747,7 +9775,7 @@ Items:
             IsStatic: false
             Components:
               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                Id: 241e3552-1857-4869-90fb-9228dc1fc1ad
+                Id: 751c0c20-b78d-4bff-8703-733747c2e95a
                 IsEnabled: true
                 LocalOrientation:
                   W: 1.0
@@ -9789,7 +9817,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 03373bc2-80d9-46db-b94e-e007dbb0a72b
+                    Id: a599bbde-151c-43dd-a15c-dd8039a6d3ba
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -9805,13 +9833,13 @@ Items:
                       Y: 1.0
                       Z: 1.0
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.PinchSlider,Evergine.MRTK
-                    Id: cc0ca081-2299-4de7-a510-2fcdebcecf19
+                    Id: 71924470-8165-4fcb-a04e-8b9a902becf1
                     InitialValue: 0.5
                     IsEnabled: true
                     SliderEndDistance: 0.075000003
                     SliderStartDistance: -0.075000003
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.SliderSounds,Evergine.MRTK
-                    Id: cf7d7512-5f40-4c20-906d-21495ce21d14
+                    Id: c859c0ba-8f72-4500-b9cd-12a99037cab1
                     EndPitch: 1.25
                     InteractionEndSound: 8380b296-60d7-41ff-af98-f8a7e4c8f43b
                     InteractionStartSound: 6828c3e0-fcd7-41d0-8643-5fb8dc589a43
@@ -9830,7 +9858,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 1d17d3c6-b9c9-4d40-906e-31701fc5e503
+                        Id: 6c7c1728-83ce-491a-8ea4-3f0236f9e488
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -9853,7 +9881,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: f062944a-a414-47cc-b888-470962318a1b
+                            Id: 0c792e02-a78a-4e78-8ffe-6ebeb2cec176
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -9869,27 +9897,27 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 6447e043-e008-46b7-a996-5a11f2930a8a
+                            Id: cb793f99-e97d-498b-b26e-60c644ebdbfc
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 1eb22db1-a530-42a0-8873-a556f60f03f2
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                            Id: fa756f19-293e-4266-92df-995b017b18c1
+                            Id: 91f753b4-8738-4203-9569-8aef29499685
                             Diameter: 0.00200000009
                             Height: 0.149999842
                             IsEnabled: true
                             Tessellation: 16
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: a500f6f3-599d-49e5-a4e8-7c34e4aefbb1
+                            Id: b8a0ed24-5a49-4a35-8360-89bc0cb94d27
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 1c299d49-bb68-4032-913f-edaa6e3501dc
-                    Id: 76dd6a92-4a4c-4102-8272-39aa72ce3605
+                        Id: 97a7c257-9de7-4fee-985c-ab979c20f4c4
+                    Id: 532a8844-3667-4746-afd7-b4390067a6c7
                   - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                     Name: SliderThumb
                     Tag: null
@@ -9897,7 +9925,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 9e4e3ade-c904-4113-a614-2bc03045bf35
+                        Id: 42237c57-7c13-4a76-a1e6-4c96f39000b6
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -9913,7 +9941,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 1ecd8c0f-0607-44b8-aeda-7536ab9f2833
+                        Id: 9c61a9de-6b7c-4161-846e-1664beb988b1
                         IsEnabled: true
                         Margin: 0.00100000005
                         Offset:
@@ -9930,7 +9958,7 @@ Items:
                           Y: 0.0399999991
                           Z: 0.0399999991
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 5ae8e4c0-cb77-44e0-a508-36530b6b7c8b
+                        Id: e8dd6d5f-ebd0-403b-bae0-7584f49ab777
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -9942,7 +9970,7 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionGrabbable,Evergine.MRTK
-                        Id: 93a89021-688c-44bc-a391-46dd1e2ef484
+                        Id: 848fa950-417f-4aa7-8f4f-c1372b462c49
                         IsEnabled: true
                     Children:
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -9952,7 +9980,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 0b980ef2-7e7d-459b-bb23-8571b62e4359
+                            Id: de2d95d1-08fd-4200-961a-b5c472c1b823
                             IsEnabled: true
                             LocalOrientation:
                               W: 0.707106888
@@ -9968,25 +9996,25 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 6a8c2d32-fd52-4758-93b2-9384211a980f
+                            Id: a6702f02-371b-42b3-b584-facd972572f5
                             AsignedTo: lambert1
                             IsEnabled: true
                             Material: 207c3402-9a1e-43ed-a8a1-11dabe70811d
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.MeshComponent,Evergine.Framework
-                            Id: 3180b8fc-1962-4c72-af29-55157aa99823
+                            Id: 1ad3d01e-56cc-47f3-99a9-4262e0fea47a
                             IsEnabled: true
                             Model: d062dd03-25f9-4635-af8c-7435b93bbfd2
                             ModelMeshName: Button_Oval_Concave_12x24mm
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 2d3fe40f-47f7-4d4d-8455-f5f3e069e3d9
+                            Id: 8c10c1f7-da42-455f-b3cf-4c3ab01e3215
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 7f2a7219-6149-4e57-8245-fa0953c6196f
+                        Id: ae8ec367-61fd-4568-9375-f70029e10fa6
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Text
                         Tag: PART_Text
@@ -9994,7 +10022,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 426a9ede-c4e1-4a97-a34d-102d64d2cfc1
+                            Id: 228c78e4-d7f2-45c0-bb8a-4fdd6407118b
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -10017,7 +10045,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 27982c6d-0461-4e29-ae8a-c92070b0d4dc
+                                Id: d5b6151e-a37b-4ff1-8de2-7df907ce2424
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10033,7 +10061,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 3aad0b3e-2123-40e3-9642-8cbce2e53c7b
+                                Id: 881b67c6-fa8f-4066-b641-22353fe102a4
                                 Color:
                                   A: 255
                                   B: 255
@@ -10057,7 +10085,7 @@ Items:
                                 VerticalAlignment: Bottom
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 7031d63f-2e80-4dc3-b200-4b3d8947a6cf
+                                Id: a9f31dbd-5868-4537-a907-e71f6eaf07f9
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10065,7 +10093,7 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: b4dfc2b8-e3af-4b26-8291-e88dfcf4fcbe
+                            Id: 4459bde7-d43b-4483-abb2-23c694844a2a
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Value
                             Tag: PART_Value
@@ -10073,7 +10101,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 2a29c1a2-1e4a-4236-a1a1-7bb139232dc3
+                                Id: d7f1ba5c-80f6-47a0-8702-2391982c0763
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10089,7 +10117,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 700a6516-ced4-40b3-9270-992ad4aea531
+                                Id: 4e1a46e8-b2ff-4c0b-a1c5-beb52144c59b
                                 Color:
                                   A: 255
                                   B: 255
@@ -10113,7 +10141,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: ac87f943-a292-452b-8daf-31708987ffa3
+                                Id: e616aec6-1284-476b-b170-9a31cec1f8c7
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10121,13 +10149,13 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                               - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.ShowSliderValue,Evergine.MRTK
-                                Id: cc200279-2f5d-4634-ad6e-4121e1f9347c
+                                Id: 39be6d82-cd47-4ac6-9ae0-330cc3605c8a
                                 IsEnabled: true
                             Children: []
-                            Id: 56f11834-79f3-4713-a303-06badb3cf25a
-                        Id: 4bb5d4ae-6d26-42a3-8b99-f0ff29be247e
-                    Id: 9a9dff8a-e42e-4e72-87f6-108d7f372410
-                Id: fe9f6d12-c8b4-40e3-8a64-d3b856c80318
+                            Id: cd1b1c71-32cd-4e94-b16b-b0b22368533f
+                        Id: 635389f2-fc09-4b23-b372-244838fe8284
+                    Id: 151c685a-0ce0-4f6e-ae75-ef88d26bb7b7
+                Id: 48eaccb7-8cdf-46b3-96cf-662eb5a539b0
             Id: be3a392a-ca0f-4029-be6c-371268e8bd58
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
             Name: PinchSlider_Green
@@ -10136,7 +10164,7 @@ Items:
             IsStatic: false
             Components:
               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                Id: 4d927222-d5c9-4951-b628-531343d8b492
+                Id: 6c290d45-2e39-4c50-987b-58125fceb68f
                 IsEnabled: true
                 LocalOrientation:
                   W: 1.0
@@ -10178,7 +10206,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 4d9e64e2-1cb1-4382-9d3d-3fcadcefc921
+                    Id: 3093e52f-867e-44cd-9472-968ec67b5562
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -10194,13 +10222,13 @@ Items:
                       Y: 1.0
                       Z: 1.0
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.PinchSlider,Evergine.MRTK
-                    Id: 63bc614f-0b3b-4224-9ea6-2ec204ceb001
+                    Id: 482d56f7-be9a-48de-a321-f0c7d1ea532a
                     InitialValue: 0.5
                     IsEnabled: true
                     SliderEndDistance: 0.075000003
                     SliderStartDistance: -0.075000003
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.SliderSounds,Evergine.MRTK
-                    Id: a869a6e7-b471-41fe-81f0-0a821f09f623
+                    Id: 1c08a667-93b8-4f94-be3f-b7ca3f476b83
                     EndPitch: 1.25
                     InteractionEndSound: 8380b296-60d7-41ff-af98-f8a7e4c8f43b
                     InteractionStartSound: 6828c3e0-fcd7-41d0-8643-5fb8dc589a43
@@ -10219,7 +10247,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: a310e3e7-857a-4206-b770-b91db462ef5e
+                        Id: 8b93a438-9ff9-4d13-b465-e20ca9d652bf
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -10242,7 +10270,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 2f8b5dbd-565e-49b0-866c-f31bc74648b2
+                            Id: 525601a4-8de4-44a9-9892-a7498406ad30
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -10258,27 +10286,27 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 50fd03d4-22cd-48ad-9fbf-bfe4cff12089
+                            Id: e8dfd46c-53a3-4962-aa35-0a065efd94cc
                             AsignedTo: Default
                             IsEnabled: true
                             Material: c3e0700e-b748-4613-82e7-c0de2ecf3c45
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                            Id: 90c44e26-858e-4bbb-bb95-63aa784a1f09
+                            Id: f6b001c7-6d74-46c0-97b5-16795e062f0b
                             Diameter: 0.00200000009
                             Height: 0.149999842
                             IsEnabled: true
                             Tessellation: 16
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: a8e6ab64-1d8b-43c0-8953-da8b015cc6aa
+                            Id: aad54052-0f6d-4bb7-9f13-22d80a49132b
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: ef50a0c0-4087-4c58-9968-a34551d7d673
-                    Id: 29ae6f5d-97e0-4682-8526-0cc58baf2c40
+                        Id: a3827754-e716-492c-8f13-706c359a1c1c
+                    Id: 69fc9aff-5335-46ff-8c25-5699242d54f9
                   - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                     Name: SliderThumb
                     Tag: null
@@ -10286,7 +10314,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 245bea84-0ec3-469f-8c4e-9f9d4b84121e
+                        Id: 2ae02928-b0a0-4985-898f-53105ae5788f
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -10302,7 +10330,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 5acc289f-2d31-446e-b92a-80d3c9434254
+                        Id: 0241aa47-2792-47a3-9c5c-d550950d52a4
                         IsEnabled: true
                         Margin: 0.00100000005
                         Offset:
@@ -10319,7 +10347,7 @@ Items:
                           Y: 0.0399999991
                           Z: 0.0399999991
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 1ae507ed-9179-40ec-840d-6a4927fabd75
+                        Id: ba22d980-6dc7-4993-97fe-67e4e1dc13e9
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -10331,7 +10359,7 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionGrabbable,Evergine.MRTK
-                        Id: 7c437208-c5eb-4d71-99db-071a20ac422b
+                        Id: 15520af4-d5a5-42ef-9501-db98ec2c97fc
                         IsEnabled: true
                     Children:
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -10341,7 +10369,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: e54b98f8-da08-4721-9a0e-81f641e80f42
+                            Id: a162caa4-131d-48fe-9816-bcc9f2591fd1
                             IsEnabled: true
                             LocalOrientation:
                               W: 0.707106888
@@ -10357,25 +10385,25 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 22cb63fe-4a54-4c38-9541-2895dd0438f5
+                            Id: f9a9a81d-8f97-4bbc-9f1f-ff66c352f25c
                             AsignedTo: lambert1
                             IsEnabled: true
                             Material: 207c3402-9a1e-43ed-a8a1-11dabe70811d
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.MeshComponent,Evergine.Framework
-                            Id: 9eb73c31-bf56-4690-8fea-2822fc83e68c
+                            Id: e31c95df-004d-49b2-ab04-6dfcb4726b32
                             IsEnabled: true
                             Model: d062dd03-25f9-4635-af8c-7435b93bbfd2
                             ModelMeshName: Button_Oval_Concave_12x24mm
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 6c134f7e-49e4-4248-a89f-7105864a2254
+                            Id: a85798ff-8b5d-4164-a61a-04d73b4971f4
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 67c19f15-1fa4-4f33-b445-b816dfb25a45
+                        Id: 7ee3856c-e382-4d9e-8f47-dcd2836ce984
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Text
                         Tag: PART_Text
@@ -10383,7 +10411,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: ce852a0b-9748-4c4c-92c3-c7f33461be19
+                            Id: 5a8ea032-7baf-423c-b173-22579287247c
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -10406,7 +10434,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 6e11e718-2bd4-4d57-9581-346dbe8d299b
+                                Id: 79e802c2-3bb3-435d-be4b-e570ee83853f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10422,7 +10450,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: c56299cc-014f-4571-886a-f90fd952f645
+                                Id: 556b08b2-5efa-42bb-9014-2d7fbc67f1e1
                                 Color:
                                   A: 255
                                   B: 255
@@ -10446,7 +10474,7 @@ Items:
                                 VerticalAlignment: Bottom
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 2e897ab1-a90e-4c1f-bb23-87fe53eed83e
+                                Id: 96c478b9-6060-4df2-987c-13b2c7d69872
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10454,7 +10482,7 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 88819ea7-f287-4181-8837-9ccba9c43732
+                            Id: b0c6aeb9-1f41-4a04-b4d8-44fe3cb1610a
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Value
                             Tag: PART_Value
@@ -10462,7 +10490,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: fe0473cc-265c-4756-a3df-39a74125e69b
+                                Id: 9b6e9596-11ad-48d4-a7a6-33aa5c546087
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10478,7 +10506,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 84de4b59-0b8f-43fc-86e6-87580a73ff09
+                                Id: 3a5bb952-d989-4e23-bac2-060a872cae83
                                 Color:
                                   A: 255
                                   B: 255
@@ -10502,7 +10530,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: ec3336cb-defe-44b5-aa54-2731a43eda23
+                                Id: f31db098-bc02-4759-a7b4-e3050513f4d4
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10510,13 +10538,13 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                               - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.ShowSliderValue,Evergine.MRTK
-                                Id: 2b3b14f8-4db7-45d9-826c-001d437bb45a
+                                Id: 225a7f11-5b05-49ba-b006-92e19c863ecc
                                 IsEnabled: true
                             Children: []
-                            Id: 162c5f76-a954-4446-a79d-7ab72cbce794
-                        Id: 890d348b-f3b6-406e-b82d-ce4998231f04
-                    Id: 344cd6ba-5c9c-41ac-b6a1-20a1e90a709d
-                Id: 4b8ad00e-f832-44ce-aa1b-b6397ffd5a37
+                            Id: 2e10c3a1-af51-476b-a987-31ad004f3aa4
+                        Id: f7ad7baf-1d47-4106-9810-fb44f71ca0d7
+                    Id: 0d2c2ed0-56a5-4df2-8b75-8c461eb6595c
+                Id: 622ef578-97a7-470a-9831-f465f475684a
             Id: 559cc2bd-9c60-4fdf-b0c9-33e03d480fed
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
             Name: PinchSlider_Blue
@@ -10525,7 +10553,7 @@ Items:
             IsStatic: false
             Components:
               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                Id: 484e4c9a-5e8c-4637-b52f-c4f9bd88ddb6
+                Id: 1357ef74-1ce4-44d2-910a-91e31422f2ae
                 IsEnabled: true
                 LocalOrientation:
                   W: 1.0
@@ -10567,7 +10595,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: 1e00ae93-745e-4870-94fe-ebd3c2a6bf76
+                    Id: 11f2fd3b-7c5c-4b90-b5a9-cb2f22a8ff85
                     IsEnabled: true
                     LocalOrientation:
                       W: 1.0
@@ -10583,13 +10611,13 @@ Items:
                       Y: 1.0
                       Z: 1.0
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.PinchSlider,Evergine.MRTK
-                    Id: 2253e608-1f0f-4a73-ba8c-049f0cc223ca
+                    Id: d0b94d7c-62fc-405a-9752-126938479cb4
                     InitialValue: 0.5
                     IsEnabled: true
                     SliderEndDistance: 0.075000003
                     SliderStartDistance: -0.075000003
                   - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.SliderSounds,Evergine.MRTK
-                    Id: a0bbf41c-c60e-45d9-befe-3edf9b7987e4
+                    Id: 0608dc38-3ce9-4ada-bedc-266166bd0932
                     EndPitch: 1.25
                     InteractionEndSound: 8380b296-60d7-41ff-af98-f8a7e4c8f43b
                     InteractionStartSound: 6828c3e0-fcd7-41d0-8643-5fb8dc589a43
@@ -10608,7 +10636,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: a35f1f76-5c9c-4c39-9b5f-8859d7ff7b81
+                        Id: f82fbe71-d18e-4a04-9769-91e93b203f5d
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -10631,7 +10659,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 13ec83d0-4cb9-4fd5-9407-fbc8395ee67b
+                            Id: f5988197-312c-4d3b-a214-9823c1cbc454
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -10647,27 +10675,27 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 050eeaa9-20c9-4d41-9929-65d652bf1489
+                            Id: c166610a-8eff-4643-9632-4e17cfa75bc8
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 29a88f02-4265-419f-9b61-b3b786fa6b30
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.CylinderMesh,Evergine.Components
-                            Id: 5d354d7c-6fb0-4985-a018-73a6c286185b
+                            Id: ae004b0a-b3dc-4d6e-9ee4-e86cc3ae76cd
                             Diameter: 0.00200000009
                             Height: 0.149999842
                             IsEnabled: true
                             Tessellation: 16
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 47ee8742-035b-42aa-b0d8-bcf0da964444
+                            Id: 4feae0f5-6f87-4585-9028-3614dc633696
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 4d948ecf-848d-40ce-93a7-4d0638bbac8a
-                    Id: 2b7453d2-56e6-444a-86c3-e667506839d2
+                        Id: 7dc1380c-44f8-4c34-9cac-393c96f890d1
+                    Id: d04d00ac-4867-488c-b981-25947eab4428
                   - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                     Name: SliderThumb
                     Tag: null
@@ -10675,7 +10703,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 9fb7bc90-8212-481f-a475-75bb710f59da
+                        Id: 334a349d-7af5-496a-97e6-1dbe33ffdc93
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -10691,7 +10719,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: 36b3a8e6-3d4b-4a29-822e-e20a0e2439e7
+                        Id: 42ad811c-eaa5-4bf0-b67e-40d4604b34da
                         IsEnabled: true
                         Margin: 0.00100000005
                         Offset:
@@ -10708,7 +10736,7 @@ Items:
                           Y: 0.0399999991
                           Z: 0.0399999991
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: df4afcd0-1321-4cbf-bf72-7559411d9a0a
+                        Id: 303972ac-7da9-4383-9b4c-4a8335fbcd77
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -10720,7 +10748,7 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionGrabbable,Evergine.MRTK
-                        Id: 133bf939-b613-4f7c-bcd5-2efb519d6f3f
+                        Id: daac381d-c5a3-43cc-8abc-ad919975fbde
                         IsEnabled: true
                     Children:
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
@@ -10730,7 +10758,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 52cfda5d-38f9-410c-a58f-a5731ba87d59
+                            Id: 0a538e07-4f8d-4a18-9952-8d6145e7fb5f
                             IsEnabled: true
                             LocalOrientation:
                               W: 0.707106888
@@ -10746,25 +10774,25 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 1b756938-4510-4ede-9271-6c96a052e38a
+                            Id: 052cafb1-9484-4478-b4d2-e58baca3b102
                             AsignedTo: lambert1
                             IsEnabled: true
                             Material: 207c3402-9a1e-43ed-a8a1-11dabe70811d
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.MeshComponent,Evergine.Framework
-                            Id: 9cc78359-1725-4e91-84f5-74d18c52a419
+                            Id: 206b6a95-3396-45ba-bf09-c9ab17835824
                             IsEnabled: true
                             Model: d062dd03-25f9-4635-af8c-7435b93bbfd2
                             ModelMeshName: Button_Oval_Concave_12x24mm
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: 181846d2-af62-4d6b-b806-9e2ec38266b9
+                            Id: ff580bf9-0208-45f6-a9a9-b99618e98a56
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: f6673676-106b-4539-ac6e-c02294a150da
+                        Id: bda6f535-0937-4dad-b5da-395f4f9ee1b3
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Text
                         Tag: PART_Text
@@ -10772,7 +10800,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: 7139462e-fc21-494c-99d6-5de692ab6277
+                            Id: 92051b30-1cc2-4e56-aa69-467b0bf8997a
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -10795,7 +10823,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: cd58b4a4-e3c4-4ce1-8e90-4816c688cef6
+                                Id: 538e1616-5bab-4bbe-a051-85efc537900e
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10811,7 +10839,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 9b238a80-446d-4f7c-8d47-ae918cd2d599
+                                Id: 12f68e3b-6290-4c42-a24d-fb6ceb75fb7a
                                 Color:
                                   A: 255
                                   B: 255
@@ -10835,7 +10863,7 @@ Items:
                                 VerticalAlignment: Bottom
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 73c8ca24-8479-4675-8d6c-832f4aa3173a
+                                Id: 93ea3c8c-1ddc-4c06-989b-5e0cf220918d
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10843,7 +10871,7 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: d0c270f1-c960-4d0a-b831-4e76e1e6cba5
+                            Id: 7a4f44f2-3024-4598-9677-c5e73ba0f691
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Value
                             Tag: PART_Value
@@ -10851,7 +10879,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 15d553f9-eec8-43b9-91ca-279bfbffcdb2
+                                Id: bc7c3b25-b7a9-4cfb-8bc2-b5a469e2baf6
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: -4.37113883E-08
@@ -10867,7 +10895,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: 11900d66-e8ea-48d8-b809-20856017d49c
+                                Id: 9a7987f6-4998-4b69-96e5-dcb5782fc4d3
                                 Color:
                                   A: 255
                                   B: 255
@@ -10891,7 +10919,7 @@ Items:
                                 VerticalAlignment: Top
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 2a5b35dc-bc8d-488d-8a56-abe7c3e78a6f
+                                Id: 4c37f84a-1234-456a-963e-3545b959eeda
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -10899,13 +10927,13 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                               - !Evergine.MRTK.SDK.Features.UX.Components.Sliders.ShowSliderValue,Evergine.MRTK
-                                Id: c8f81e0a-2a5c-4503-a03f-778240617a5a
+                                Id: 82c96d29-ef99-408a-8555-07e057f52daf
                                 IsEnabled: true
                             Children: []
-                            Id: f1d86eb9-7b24-4485-9c7d-f6de2f310866
-                        Id: c897852f-bde9-4b59-a9fc-7fb53f5a29dd
-                    Id: 58c1b6d5-27f4-4a7a-b617-a8875b160e09
-                Id: 3e73c102-52be-434e-9f33-450c6bddf7d4
+                            Id: f3d92a7f-9354-455f-aaeb-98c4a40a55e7
+                        Id: f4288648-95b2-4499-86f7-2299444be51e
+                    Id: 563f880d-c947-45c9-a690-bbc5394a0ece
+                Id: 0a63516d-9b3c-4f64-8090-fe448d548635
             Id: 0a34e324-74ff-4f5f-a3b9-a3c8d6f5519c
           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
             Name: SectionTitle
@@ -15365,7 +15393,7 @@ Items:
                 IsStatic: false
                 Components:
                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                    Id: cb9f6206-4bb3-49a8-9c5e-e3023cf563ac
+                    Id: 621ea00b-8686-41f5-947b-d8c02df3c173
                     IsEnabled: true
                     LocalOrientation:
                       W: -4.37113883E-08
@@ -15432,7 +15460,7 @@ Items:
                     IsStatic: false
                     Components:
                       - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                        Id: 50613075-1552-4d01-a9fd-0cdb08f91a81
+                        Id: 6ad5c33a-105d-4360-8438-b571e0655feb
                         IsEnabled: true
                         LocalOrientation:
                           W: 1.0
@@ -15448,7 +15476,7 @@ Items:
                           Y: 1.0
                           Z: 1.0
                       - !Evergine.Framework.Physics3D.BoxCollider3D,Evergine.Framework
-                        Id: fd16068e-7d4e-4b35-8ece-e9d0b7733f57
+                        Id: 5dce4d2b-dea6-42e5-9c62-0958e8ccbdc4
                         IsEnabled: true
                         Margin: 0.0
                         Offset:
@@ -15465,7 +15493,7 @@ Items:
                           Y: 0.0320000015
                           Z: 0.0160000008
                       - !Evergine.Framework.Physics3D.StaticBody3D,Evergine.Framework
-                        Id: 9eee4edc-57c1-4141-af07-a7accba4a466
+                        Id: abb8d416-835f-4625-8c33-07de615910f8
                         CcdMotionThreshold: 0.0
                         CcdSweptSphereRadius: 0.200000003
                         CollisionCategories: Cat1
@@ -15477,9 +15505,10 @@ Items:
                         RollingFriction: 0.0
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButton,Evergine.MRTK
-                        Id: 83b4ef40-fc08-4fd1-9f99-b8c19604a7ce
+                        Id: 8e3421ad-a845-45e5-87c9-b8776afd46b0
                         EndPosition: -0.100000001
                         EnforceFrontPush: true
+                        FocusSelectionTime: 0:00:00:00.0000000
                         IsEnabled: true
                         PressPosition: 0.100000001
                         ReleasePosition: 0.300000012
@@ -15489,10 +15518,10 @@ Items:
                         StartPosition: 0.5
                         UpdateOrder: 0.5
                       - !Evergine.MRTK.Services.InputSystem.NearInteractionTouchable,Evergine.MRTK
-                        Id: f66956ae-7f60-4a8f-9f36-a391cc330921
+                        Id: aefe14d1-8742-4219-9c9a-5df2ef79ad49
                         IsEnabled: true
                       - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonSoundFeedbackComponent,Evergine.MRTK
-                        Id: 54a8662c-a913-48a1-95be-67bba4183738
+                        Id: d645c3d8-6fb8-4469-a6a2-b10b04fb5378
                         IsEnabled: true
                         PressedSound: 2f03824d-5709-4c4d-9857-c6a47769a5bc
                         ReleasedSound: 7f835fa0-da0a-4152-b6ee-157943781e61
@@ -15504,7 +15533,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: c81cba67-965f-4c5b-8450-1a93342d92f4
+                            Id: 0a0edfc5-0d24-4238-afbb-ade905f983fa
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -15520,13 +15549,13 @@ Items:
                               Y: 0.0320000015
                               Z: 0.0100008119
                           - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                            Id: 1b58ab09-e583-4c98-beb7-de36d0d296a0
+                            Id: db813c89-1f44-4cf4-9f86-c2f55c3ce07f
                             AsignedTo: Default
                             IsEnabled: true
                             Material: 4f32ee6e-22c9-48be-ad27-76ba638454fb
                             UseCopy: false
                           - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                            Id: 5d244d87-5ca4-4cf0-95c9-2fa792180e12
+                            Id: ce799e90-9889-48ff-ac83-1bb0acf20f77
                             Height: 1.0
                             IsEnabled: true
                             Origin:
@@ -15542,14 +15571,14 @@ Items:
                             VTile: 1.0
                             Width: 1.0
                           - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                            Id: c467da12-6d15-4307-963a-f5b954c259e8
+                            Id: f1b4cb35-af1d-4041-93b8-f34beef04fb2
                             DebugBoundingbox: true
                             IsCullingEnabled: true
                             IsEnabled: true
                             OrderBias: 0
                             RenderFlags: CastShadows
                         Children: []
-                        Id: 70f85c35-5c07-43ee-b578-9efb1070d369
+                        Id: 1f8c7500-5791-4310-8d24-89576c52293e
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: Content
                         Tag: null
@@ -15557,7 +15586,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: ce456d1a-88a2-4ee0-8fa0-1c35d9d2e24b
+                            Id: 163d7277-14b3-40af-8bbb-2fd321a6c02e
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -15573,7 +15602,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: 540cde63-2984-44f0-a539-bf230887c451
+                            Id: d5afd245-fe84-4df1-9054-90e67c9f2826
                             ChangeColor: false
                             Compressable: false
                             FocusedAccentDistance: 0.00200000009
@@ -15589,7 +15618,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 03ee451b-2df9-49a8-9ec4-ff17c4ee2082
+                                Id: 6036c551-1dc4-4ca5-9278-fa414cb26aa8
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -15605,13 +15634,13 @@ Items:
                                   Y: 0.0149999997
                                   Z: 0.0149999997
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 1480ba61-3d90-483b-98ee-45443f727c41
+                                Id: dbc4e668-401e-4666-9dde-4a8a1f635db7
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 8a071514-0ac1-4640-8072-a0bd8306554f
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                Id: 216160fe-a88d-473e-8461-3ab44e5f3b74
+                                Id: e6e4ecd6-d82c-4dfa-b4a6-629f73b0af9b
                                 Height: 1.0
                                 IsEnabled: true
                                 Origin:
@@ -15627,14 +15656,14 @@ Items:
                                 VTile: 1.0
                                 Width: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 5f72e25f-4183-4b07-b6c5-a34c3497760f
+                                Id: 5a816d58-fffc-4da9-9711-3481ab6e8c87
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: f2bfbd6d-7efe-4267-b39c-5dd7003dfc2d
+                            Id: 896e2d64-f7a2-4ac9-9d5a-b9bc0a74eee7
                           - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                             Name: Text
                             Tag: PART_Text
@@ -15642,7 +15671,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: adc48207-9f46-4642-a8f6-8c0c355e1006
+                                Id: 4d627deb-1ac0-4109-bc64-26602ef3fcd2
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -15658,7 +15687,7 @@ Items:
                                   Y: 1.0
                                   Z: 1.0
                               - !Evergine.Components.Fonts.Text3DMesh,Evergine.Components
-                                Id: f8b06d79-b21b-4f6d-a522-c7f4d50b6099
+                                Id: dfed6391-128a-477a-8bb6-d14d01625f88
                                 Color:
                                   A: 255
                                   B: 255
@@ -15682,7 +15711,7 @@ Items:
                                 VerticalAlignment: Center
                                 Wrapping: true
                               - !Evergine.Components.Fonts.Text3DRenderer,Evergine.Components
-                                Id: 24ac54cd-162f-4a26-b10c-9736e8dad541
+                                Id: 78b40af2-1337-42ca-8200-cfe1aff77ed6
                                 DebugBoundingbox: true
                                 DebugMode: false
                                 IsCullingEnabled: true
@@ -15690,8 +15719,8 @@ Items:
                                 OrderBias: 0
                                 RenderFlags: CastShadows
                             Children: []
-                            Id: 3a28b671-ac5e-4211-8273-927845af0e0a
-                        Id: 5980b75a-8c83-458e-8350-db7081027468
+                            Id: ca21f140-e439-4667-aed3-ecfd7c91ea50
+                        Id: ac429f1f-398a-49af-8bc1-0a60d0fc1ba0
                       - !Evergine.Framework.Assets.AssetSources.Entities.EntityItemModel,Evergine.Framework
                         Name: CompressableButtonVisuals
                         Tag: null
@@ -15699,7 +15728,7 @@ Items:
                         IsStatic: false
                         Components:
                           - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                            Id: e71e8535-5b66-495b-85df-47c18fb1474d
+                            Id: 6d743e18-26f0-4ab7-955e-24764cd06ece
                             IsEnabled: true
                             LocalOrientation:
                               W: 1.0
@@ -15715,7 +15744,7 @@ Items:
                               Y: 1.0
                               Z: 1.0
                           - !Evergine.MRTK.SDK.Features.UX.Components.PressableButtons.PressableButtonVisualFeedbackComponent,Evergine.MRTK
-                            Id: b1a9f2d9-cf57-42f2-b4a3-dc11d893a7ed
+                            Id: ab0ef753-7dc9-4d95-b79e-ec9fb82e5d06
                             ChangeColor: false
                             Compressable: true
                             FocusedAccentDistance: 0.0
@@ -15731,7 +15760,7 @@ Items:
                             IsStatic: false
                             Components:
                               - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                Id: 1477a12f-122c-4870-a901-38ea125ce17d
+                                Id: 26d46db5-7ac1-43e9-8f98-a74d1558591f
                                 IsEnabled: true
                                 LocalOrientation:
                                   W: 1.0
@@ -15747,13 +15776,13 @@ Items:
                                   Y: 0.0320000015
                                   Z: 0.0160000008
                               - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                Id: 003f9de5-3167-486f-a154-e125dd0776b9
+                                Id: f1df3327-5556-4f02-9d82-360159543f16
                                 AsignedTo: Default
                                 IsEnabled: true
                                 Material: 75122a47-663c-4625-8118-ff2e2a2bcaeb
                                 UseCopy: false
                               - !Evergine.Components.Graphics3D.CubeMesh,Evergine.Components
-                                Id: 3db523e8-90c5-4f9d-a4f7-dad55cb1320d
+                                Id: dac89d39-151f-469e-ad45-e4b8155b1417
                                 IsEnabled: true
                                 Size: 1.0
                                 UMirror: false
@@ -15763,7 +15792,7 @@ Items:
                                 VOffset: 0.0
                                 VTile: 1.0
                               - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                Id: 5ad5a637-b82b-48d9-a016-da67e6f66aa1
+                                Id: 57c8f419-625e-4e23-89b2-b374d16e3c12
                                 DebugBoundingbox: true
                                 IsCullingEnabled: true
                                 IsEnabled: true
@@ -15777,7 +15806,7 @@ Items:
                                 IsStatic: false
                                 Components:
                                   - !Evergine.Framework.Graphics.Transform3D,Evergine.Framework
-                                    Id: 6d18e861-bc4c-430f-8df4-a92e807be8d4
+                                    Id: bc674dbe-4b19-4f19-91c8-e905b1527dc9
                                     IsEnabled: true
                                     LocalOrientation:
                                       W: 1.0
@@ -15793,13 +15822,13 @@ Items:
                                       Y: 1.0
                                       Z: 1.0
                                   - !Evergine.Components.Graphics3D.MaterialComponent,Evergine.Framework
-                                    Id: b8cb4ef1-14fd-4976-a2cf-8ca36dcde6ae
+                                    Id: 054d1bd3-fb35-4a95-83db-5db03b55bf0f
                                     AsignedTo: Default
                                     IsEnabled: true
                                     Material: 876d9b5c-5016-4796-8473-92a19a5d244c
                                     UseCopy: false
                                   - !Evergine.Components.Graphics3D.PlaneMesh,Evergine.Components
-                                    Id: 503b94b8-2275-46d8-9b50-51a58aa9a55a
+                                    Id: 4e1dec90-05e5-4d92-af4c-5df9631d44ac
                                     Height: 1.0
                                     IsEnabled: true
                                     Origin:
@@ -15815,17 +15844,17 @@ Items:
                                     VTile: 1.0
                                     Width: 1.0
                                   - !Evergine.Components.Graphics3D.MeshRenderer,Evergine.Framework
-                                    Id: 916b505a-1e5d-41ff-9183-9ae9a7294afd
+                                    Id: 44ecc256-4273-47d5-975a-cc8010956730
                                     DebugBoundingbox: true
                                     IsCullingEnabled: true
                                     IsEnabled: true
                                     OrderBias: 0
                                     RenderFlags: CastShadows
                                 Children: []
-                                Id: eca92796-5d0b-4cfc-ac25-c7f98cacd9b5
-                            Id: 7073f2d9-8543-465f-ae86-dbd45cc7938e
-                        Id: 7ada07f3-5ce7-406a-bdf0-0033e0b672ca
-                    Id: 74242346-f563-49be-a2e5-e11a307f5785
+                                Id: 461ac4f2-8901-416e-b996-5de33e72717c
+                            Id: afa53515-3476-4d66-b600-73a6f8fb1ed8
+                        Id: 8f2a15d6-5265-4014-921e-6812f5b46773
+                    Id: 7e225834-1231-4c04-ad3a-e6b4ecd6afa4
                 Id: b85f2c1e-5df7-42cf-94d1-619f6c3ace5c
             Id: 64c571fd-198c-4bf2-a4b2-cb00ae214192
         Id: acf8f22c-a81d-4141-8359-35ba190b5d66
@@ -15833,7 +15862,7 @@ Items:
 Managers:
   - !Evergine.Framework.Managers.EnvironmentManager,Evergine.Framework
     Id: 0b6695c7-b505-442d-b0e2-8e2791c63949
-    IBLReflectionProbe: 82e82c4b-7ed3-42fe-8bd0-848e7a5d2819
+    IBLReflectionProbe: 38a5d19c-8a9d-4210-b582-570fec9b4234
     IntensityMultiplier: 1.0
     IsEnabled: true
     Strategy: Automatically

--- a/Source/Evergine.MRTK/Emulation/GazeProvider.cs
+++ b/Source/Evergine.MRTK/Emulation/GazeProvider.cs
@@ -227,11 +227,6 @@ namespace Evergine.MRTK.Services.InputSystem
 
                 var result = this.Managers.PhysicManager3D.RayCast(ref fromPosition, ref toPosition, this.CollisionCategoryMask);
 
-                if (result.Succeeded)
-                {
-                    this.Managers.RenderManager.LineBatch3D.DrawPoint(result.Point, 0.1f, Color.Red); 
-                }
-
                 this.GazeTarget = result.Succeeded ? result.PhysicBody.BodyComponent.Owner : null;
 
                 // Update gaze pointer

--- a/Source/Evergine.MRTK/Emulation/GazeProvider.cs
+++ b/Source/Evergine.MRTK/Emulation/GazeProvider.cs
@@ -45,10 +45,22 @@ namespace Evergine.MRTK.Services.InputSystem
 
         private ISphereColliderShape3D gazePointerShape;
 
+        private bool eyeGazeAllowed;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Eye gaze will be used as a gaze provider.
+        /// </summary>
+        public bool EnableEyeGaze { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the max distance to capture.
         /// </summary>
         public float Distance { get; set; } = 10.0f;
+
+        /// <summary>
+        /// Gets a value indicating whether the eye gaze has been allowed to be used in the application.
+        /// </summary>
+        public bool EyeGazeAllowed => this.eyeGazeAllowed;
 
         /// <summary>
         /// Gets or sets a value indicating whether the gaze pointer should have an hover light.
@@ -147,6 +159,11 @@ namespace Evergine.MRTK.Services.InputSystem
                    .AddComponent(this.gazePointerTransform)
                    .AddComponent(this.gazePointerLight);
 
+            if (this.EnableEyeGaze)
+            {
+                this.RequestPermission();
+            }
+
             return true;
         }
 
@@ -188,9 +205,13 @@ namespace Evergine.MRTK.Services.InputSystem
             if (this.xrPlatform != null)
             {
                 ray = this.xrPlatform.EyeGaze;
-                if (ray == null)
+                if (!ray.HasValue)
                 {
                     ray = this.xrPlatform.HeadGaze;
+                    if (ray.HasValue && ray.Value.Direction == Vector3.Zero)
+                    {
+                        ray = new Ray(this.transform.Position, this.transform.LocalTransform.Forward);
+                    }
                 }
             }
             else
@@ -206,6 +227,11 @@ namespace Evergine.MRTK.Services.InputSystem
 
                 var result = this.Managers.PhysicManager3D.RayCast(ref fromPosition, ref toPosition, this.CollisionCategoryMask);
 
+                if (result.Succeeded)
+                {
+                    this.Managers.RenderManager.LineBatch3D.DrawPoint(result.Point, 0.1f, Color.Red); 
+                }
+
                 this.GazeTarget = result.Succeeded ? result.PhysicBody.BodyComponent.Owner : null;
 
                 // Update gaze pointer
@@ -219,6 +245,11 @@ namespace Evergine.MRTK.Services.InputSystem
             {
                 this.GazeTarget = null;
             }
+        }
+
+        private async void RequestPermission()
+        {
+            this.eyeGazeAllowed = await this.xrPlatform.RequestEyeGazePermission();
         }
     }
 }

--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/PressableButtons/IPressableButtonFeedback.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/PressableButtons/IPressableButtonFeedback.cs
@@ -22,5 +22,11 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.PressableButtons
         /// </summary>
         /// <param name="focus">Whether the button is in focus.</param>
         void FocusChanged(bool focus);
+
+        /// <summary>
+        /// Notify while the button is focused and need to apply a feedback.
+        /// </summary>
+        /// <param name="timeout">The timeout ratio. from [0-1] range, while 0 us at the begining of focus, and 1 when the button has been focused during button.FocusSelectionTime time.</param>
+        void FocusTimeout(float timeout);
     }
 }

--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/PressableButtons/PressableButtonVisualFeedbackComponent.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/PressableButtons/PressableButtonVisualFeedbackComponent.cs
@@ -125,6 +125,11 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.PressableButtons
             this.transform.LocalPosition = this.movingVisualsInitialLocalPosition + this.focusOffset;
         }
 
+        /// <inheritdoc/>
+        void IPressableButtonFeedback.FocusTimeout(float timeout)
+        {
+        }
+
         /// <summary>
         /// It's possible that other component changes default button material, that here is cached
         /// when component is attached.

--- a/Source/Evergine.MRTK/Scenes/XRScene.cs
+++ b/Source/Evergine.MRTK/Scenes/XRScene.cs
@@ -90,6 +90,11 @@ namespace Evergine.MRTK.Scenes
         /// </summary>
         public virtual CollisionCategory3D CursorCollisionCategoryMask { get; protected set; } = CollisionCategory3D.All;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the Eye Gaze will be enabled to be used in the application. The XR platform must support this feature.
+        /// </summary>
+        public virtual bool EnableEyeGaze { get; set; } = false;
+
         /// <inheritdoc/>
         public override void RegisterManagers()
         {
@@ -139,6 +144,7 @@ namespace Evergine.MRTK.Scenes
             var cam = this.Managers.EntityManager.FindFirstComponentOfType<Camera3D>();
             cam.Owner.AddComponent(new GazeProvider()
             {
+                EnableEyeGaze = this.EnableEyeGaze,
                 CollisionCategoryMask = this.CursorCollisionCategoryMask & ~this.CursorCollisionCategory,
             });
         }


### PR DESCRIPTION
# Overview

This PR introduce two changes:
- GazeProvider has been changed to allow the possibility to use the Eye Gaze. This feature is only supported in HoloLens 2 device.
- PressableButton has the property `FocusSelectionTime`. If a button is focused during the time specified in the property, the button will be pressed. Additionally, this PR modify the IPressableButtonFeedback class adding the `void FocusTimeout(float timeout)`, allowing components to represent visually the timeout process till the button will be pressed.

# How to test

1. Create a MRTK application.
2. In the XRScene, set the property `EnableEyeGaze` to `true`, this will enable the eye gaze.
3. With your eye gaze (in Hololens) or with a controller, focus one of the three round buttons during 2 seconds. The button must be pressed.

