### PR TITLE
Feature - Allow set ToogleButton state

### DIFF
--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright © Evergine S.L. All rights reserved. Use is subject to license terms.
 
 using System;
+using Evergine.Common.Attributes;
 using Evergine.Framework;
 using Evergine.MRTK.SDK.Features.UX.Components.States;
 
@@ -21,6 +22,7 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.ToggleButtons
         /// <summary>
         /// Gets or sets a value indicating whether toggle is on or not.
         /// </summary>
+        [IgnoreEvergine]
         public bool IsOn
         {
             get => this.IsOnState();

--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
@@ -21,7 +21,11 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.ToggleButtons
         /// <summary>
         /// Gets a value indicating whether button is on or not.
         /// </summary>
-        public bool IsOn { get => this.IsOnState(); }
+        public bool IsOn
+        {
+            get => this.IsOnState();
+            set => this.SetIsOnState(value);
+        }
 
         /// <inheritdoc />
         protected override bool OnAttached()
@@ -57,6 +61,14 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.ToggleButtons
         {
             var toggleState = this.GetToggleState();
             return toggleState?.Value == ToggleState.On;
+        }
+
+        private void SetIsOnState(bool isOn)
+        {
+            if (this.stateManager != null)
+            {
+                this.stateManager.ChangeState(isOn ? ToggleStateManager.State_On : ToggleStateManager.State_Off);
+            }
         }
 
         private void SubscribeEvents()

--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleButton.cs
@@ -19,7 +19,7 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.ToggleButtons
         public event EventHandler Toggled;
 
         /// <summary>
-        /// Gets a value indicating whether button is on or not.
+        /// Gets or sets a value indicating whether toggle is on or not.
         /// </summary>
         public bool IsOn
         {

--- a/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleStateManager.cs
+++ b/Source/Evergine.MRTK/SDK/Features/UX/Components/ToggleButtons/ToggleStateManager.cs
@@ -69,21 +69,22 @@ namespace Evergine.MRTK.SDK.Features.UX.Components.ToggleButtons
             return true;
         }
 
+        /// <summary>
+        /// State for when the toggle is on.
+        /// </summary>
+        public static readonly State<ToggleState> State_On = new State<ToggleState>() { Name = ToggleState.On.ToString(), Value = ToggleState.On };
+
+        /// <summary>
+        /// State for when the toggle is off.
+        /// </summary>
+        public static readonly State<ToggleState> State_Off = new State<ToggleState>() { Name = ToggleState.Off.ToString(), Value = ToggleState.Off };
+
         /// <inheritdoc />
         protected override List<State<ToggleState>> GetStateList()
         {
             var states = new List<State<ToggleState>>();
-            states.Add(new State<ToggleState>
-            {
-                Name = ToggleState.Off.ToString(),
-                Value = ToggleState.Off,
-            });
-            states.Add(new State<ToggleState>
-            {
-                Name = ToggleState.On.ToString(),
-                Value = ToggleState.On,
-            });
-
+            states.Add(State_Off);
+            states.Add(State_On);
             return states;
         }
 


### PR DESCRIPTION
This change allows setting the state of a ToggleButton in code.
While it was possible to do so before, you had to do it though the ToggleStateManager component, and you had to loop though the possible states to find the exact instance of the state you need.
Now it's as easy as setting the bool property "IsOn".